### PR TITLE
Add office customization: per-player desks with 2D layout editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Copy `.env.example` to `.env.local` and populate:
 - `SESSION_SECRET` — Express session + JWT signing secret
 - `APP_URL` — Canonical app URL (used for OAuth redirect URI construction)
 - `GEMINI_API_KEY` — Google Gemini API key (injected into Vite build via `vite.config.ts`)
-- `DATABASE_URL` — PostgreSQL connection string; server auto-creates `users` table on startup (stores `paper_reams` and `avatar_config` per email)
+- `DATABASE_URL` — PostgreSQL connection string; server auto-creates `users` and `room_layouts` tables on startup
 
 ## Architecture
 
@@ -31,21 +31,24 @@ Copy `.env.example` to `.env.local` and populate:
 
 **Multiplayer rooms** (`src/hooks/useSocket.ts`): Server maintains `rooms: Record<roomId, Record<socketId, PlayerState>>`. Room is passed via `?room=<id>` URL query param. Players join by emitting `joinRoom`. Movement is synced via `playerMovement` events; chat via `chatMessage`. The hook owns all socket lifecycle, player state, and chat history.
 
-**App.tsx**: Thin orchestrator — composes `useAuth` + `useSocket`, manages `currentRoom`, and renders the appropriate screen (loading → disconnected → login → room select → game).
+**App.tsx**: Thin orchestrator — composes `useAuth` + `useSocket`, manages `currentRoom`, and renders the appropriate screen (loading → disconnected → login → room select → game → customize-office).
 
 **3D world** (`src/components/`): React Three Fiber (`@react-three/fiber`) + Drei. The `Canvas` is set up in `App.tsx`.
 - `player/LocalPlayer.tsx` — Camera-relative WASD movement, desk snapping during focus. Physics delegated to `usePlayerPhysics`.
 - `player/OtherPlayer.tsx` — Renders remote players from socket state.
 - `player/CharacterAvatar.tsx` — Animated 3D character mesh (walk/jump/roll poses).
-- `world/OfficeEnvironment.tsx` — Room orchestrator; imports `Desk`, `Chair`, `BeetFarm`, `Banner`.
+- `world/OfficeEnvironment.tsx` — Room orchestrator; renders desks from `roomLayout` store state (dynamic, not from constants).
 - `world/Desk.tsx` — Desk + proximity detection; shows "[E] to Start Focus" prompt via `nearestDeskId` in store.
-- `ui/HUDPanel.tsx` — Left overlay (stats + controls guide).
+- `ui/HUDPanel.tsx` — Left overlay (stats + controls guide + "Customize Office" button).
 - `ui/ChatPanel.tsx` — Right overlay (chat history + input + emotes).
+- `ui/OfficeCustomizationPage.tsx` — Top-down 2D SVG editor for repositioning desks; desks are draggable with ±45° rotation controls.
 
 **Physics hook** (`src/hooks/usePlayerPhysics.ts`): Encapsulates all movement refs and logic — `processJump` (double jump), `processRoll` (double-tap W), `tickRoll`, `applyGravity`, `applyMovement` (axis-separated collision tests against `COLLISION_BOXES` and other players).
 
-**Game state** (`src/store/useGameStore.ts`): Zustand store holding Pomodoro timer state, paper reams (passive income during focus sessions), nearest/active desk IDs, and chat focus flag. Timer integration: pressing E at a desk starts a 25-min focus timer that locks movement to the desk chair; paper accumulates at 1 ream per 30 seconds.
+**Game state** (`src/store/useGameStore.ts`): Zustand store holding Pomodoro timer state, paper reams (passive income during focus sessions), nearest/active desk IDs, chat focus flag, and `roomLayout` (the live `FurnitureItem[]` for the current room). Timer integration: pressing E at a desk starts a 25-min focus timer that locks movement to the desk chair; paper accumulates at 1 ream per 30 seconds.
 
-**Constants** (`src/constants.ts`): `DESKS` array (desk positions/rotations), `COLLISION_BOXES` (`THREE.Box3` array for the entire office), and deterministic player color assignment by name hash.
+**Office layout system**: Desk positions are stored per-room in the `room_layouts` PostgreSQL table as a JSONB array of `FurnitureItem` objects. On `joinRoom`, the server calls `ensurePlayerDesk` (auto-creates a desk for new players at a grid spawn position) and emits `roomLayoutLoaded`. When any player saves a new layout via `POST /api/room-layout`, the server broadcasts `roomLayoutUpdated` to all players in the room. The `FurnitureItem` / `DeskItem` types in `src/types.ts` are extensible — future furniture types (chairs, plants, etc.) only require new render branches, no DB schema changes.
+
+**Constants** (`src/constants.ts`): `DESKS` array is kept as a legacy reference but is no longer used at runtime — desks are loaded dynamically from the DB. `COLLISION_BOXES` (`THREE.Box3` array for the entire office) and deterministic player color assignment by name hash remain in active use.
 
 **Styling**: Tailwind CSS v4 via `@tailwindcss/vite` plugin. No tailwind config file — configuration is implicit. Custom pixel-art CSS classes (`pixel-border`, `pixel-button`, `font-pixel`) are defined in `src/index.css`.

--- a/server.ts
+++ b/server.ts
@@ -29,6 +29,12 @@ async function initDb() {
   await pool.query(`
     ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_config JSONB NOT NULL DEFAULT '{}'
   `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS room_layouts (
+      room_id TEXT PRIMARY KEY,
+      layout  JSONB NOT NULL DEFAULT '[]'
+    )
+  `);
 }
 
 async function getPaperReams(email: string): Promise<number> {
@@ -69,6 +75,75 @@ async function saveAvatarConfig(email: string, config: AvatarConfig): Promise<vo
      ON CONFLICT (email) DO UPDATE SET avatar_config = EXCLUDED.avatar_config`,
     [email, JSON.stringify(config)]
   );
+}
+
+// ── Room Layout ───────────────────────────────────────────────────────────────
+
+interface FurnitureItem {
+  id: string;
+  type: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  config: Record<string, unknown>;
+}
+
+interface DeskItem extends FurnitureItem {
+  type: 'desk';
+  config: { ownerEmail: string; ownerName: string; [key: string]: unknown };
+}
+
+async function getRoomLayout(roomId: string): Promise<FurnitureItem[]> {
+  const { rows } = await pool.query(
+    'SELECT layout FROM room_layouts WHERE room_id = $1',
+    [roomId]
+  );
+  return (rows[0]?.layout as FurnitureItem[]) ?? [];
+}
+
+async function saveRoomLayout(roomId: string, layout: FurnitureItem[]): Promise<void> {
+  await pool.query(
+    `INSERT INTO room_layouts (room_id, layout) VALUES ($1, $2)
+     ON CONFLICT (room_id) DO UPDATE SET layout = EXCLUDED.layout`,
+    [roomId, JSON.stringify(layout)]
+  );
+}
+
+function generateSpawnPosition(existingDesks: DeskItem[]): [number, number, number] {
+  const columns = [-11.5, -9.0, -6.5, -4.0, -1.5];
+  const rows = [-16.5, -14.0, -11.5, -9.0, -6.5, -4.0, -2.5];
+  for (const z of rows) {
+    for (const x of columns) {
+      const occupied = existingDesks.some((d) => {
+        const dx = d.position[0] - x;
+        const dz = d.position[2] - z;
+        return Math.sqrt(dx * dx + dz * dz) < 2.5;
+      });
+      if (!occupied) return [x, 0, z];
+    }
+  }
+  // Fallback: random position in the sales floor area
+  return [Math.random() * 12 - 12, 0, Math.random() * 16 - 18];
+}
+
+async function ensurePlayerDesk(roomId: string, email: string, name: string): Promise<FurnitureItem[]> {
+  const layout = await getRoomLayout(roomId);
+  const existingDesk = layout.find(
+    (f) => f.type === 'desk' && (f as DeskItem).config.ownerEmail === email
+  );
+  if (existingDesk) return layout;
+
+  const desks = layout.filter((f): f is DeskItem => f.type === 'desk');
+  const position = generateSpawnPosition(desks);
+  const newDesk: DeskItem = {
+    id: `desk-${email}`,
+    type: 'desk',
+    position,
+    rotation: [0, 0, 0],
+    config: { ownerEmail: email, ownerName: name },
+  };
+  const updated = [...layout, newDesk];
+  await saveRoomLayout(roomId, updated);
+  return updated;
 }
 
 // ── Config ───────────────────────────────────────────────────────────────────
@@ -286,6 +361,18 @@ async function startServer() {
     res.json({ ok: true });
   });
 
+  app.post("/api/room-layout", express.json(), async (req, res) => {
+    const user = (req as any).user;
+    if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
+    const { roomId, layout } = req.body ?? {};
+    if (typeof roomId !== 'string' || !Array.isArray(layout)) {
+      return res.status(400).json({ error: "Invalid layout" });
+    }
+    await saveRoomLayout(roomId, layout as FurnitureItem[]);
+    io.to(roomId).emit("roomLayoutUpdated", layout);
+    res.json({ ok: true });
+  });
+
   app.post("/api/auth/logout", (req, res) => {
     req.session.destroy((err) => {
       if (err) console.error("Logout error:", err);
@@ -388,6 +475,15 @@ io.on("connection", (socket) => {
           // Broadcast updated player with avatar config to others
           socket.to(room).emit("newPlayer", rooms[room][socket.id]);
         }
+      });
+      // Ensure player has a desk and send the full room layout
+      ensurePlayerDesk(room, user.email, user.name).then((layout) => {
+        socket.emit("roomLayoutLoaded", layout);
+        // Broadcast updated layout to others in the room
+        socket.to(room).emit("roomLayoutUpdated", layout);
+      }).catch((err) => {
+        console.error("Error ensuring player desk:", err);
+        socket.emit("roomLayoutLoaded", []);
       });
       
       console.log(`User ${socket.id} joined room: ${room}`);
@@ -523,4 +619,7 @@ io.on("connection", (socket) => {
   });
 }
 
-startServer();
+startServer().catch((err) => {
+  console.error("Failed to start server:", err);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import { ChatPanel } from './components/ui/ChatPanel';
 import { PomodoroUI } from './components/ui/PomodoroUI';
 import { PaperBurst } from './components/ui/PaperBurst';
 import { AvatarCustomizationPage } from './components/ui/AvatarCustomizationPage';
+import { OfficeCustomizationPage } from './components/ui/OfficeCustomizationPage';
+import { FurnitureItem } from './types';
 import { OfficeEnvironment } from './components/world/OfficeEnvironment';
 import { LocalPlayer } from './components/player/LocalPlayer';
 import { OtherPlayer } from './components/player/OtherPlayer';
@@ -40,8 +42,8 @@ export default function App() {
   const { socket, players, isConnected, chatHistory, lastLocalMessage, disconnectReason, connectionError, sendMessage } =
     useSocket(user, currentRoom);
 
-  const { isTimerActive, paperReams, avatarConfig, setAvatarConfig, setPaperReams } = useGameStore();
-  const [view, setView] = useState<'landing' | 'customize'>('landing');
+  const { isTimerActive, paperReams, avatarConfig, setAvatarConfig, setPaperReams, roomLayout, setRoomLayout } = useGameStore();
+  const [view, setView] = useState<'landing' | 'customize' | 'customize-office'>('landing');
 
   const keyboardMap = useMemo(() => KEYBOARD_MAP, []);
 
@@ -78,6 +80,16 @@ export default function App() {
       })
       .catch(() => {});
   }, [user, currentRoom]);
+
+  const handleSaveOfficeLayout = useCallback(async (layout: FurnitureItem[]) => {
+    setRoomLayout(layout);
+    const token = localStorage.getItem('office_auth_token');
+    await fetch('/api/room-layout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+      body: JSON.stringify({ roomId: currentRoom, layout }),
+    });
+  }, [currentRoom, setRoomLayout]);
 
   const handleSaveAvatar = useCallback(async (config: typeof avatarConfig) => {
     setAvatarConfig(config);
@@ -157,6 +169,18 @@ export default function App() {
     );
   }
 
+  // ── Office customization (in-room) ──────────────────────────────────────
+  if (currentRoom && view === 'customize-office') {
+    return (
+      <OfficeCustomizationPage
+        roomId={currentRoom}
+        initialLayout={roomLayout}
+        onBack={() => setView('landing')}
+        onSave={handleSaveOfficeLayout}
+      />
+    );
+  }
+
   // ── Room selection ───────────────────────────────────────────────────────
   if (!currentRoom) {
     return <LandingPage onJoin={handleJoin} userName={user.name} onLogout={logout} onCustomize={() => setView('customize')} avatarConfig={avatarConfig} paperReams={paperReams} />;
@@ -179,6 +203,7 @@ export default function App() {
               currentRoom={currentRoom}
               paperReams={paperReams}
               onExitRoom={handleExitRoom}
+              onCustomizeOffice={() => setView('customize-office')}
             />
           </motion.div>
         )}

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -3,8 +3,8 @@ import { useFrame } from '@react-three/fiber';
 import { OrbitControls, useKeyboardControls, Billboard, Text } from '@react-three/drei';
 import * as THREE from 'three';
 import { Socket } from 'socket.io-client';
-import { Player } from '../../types';
-import { getDeterministicColor, DESKS } from '../../constants';
+import { Player, DeskItem } from '../../types';
+import { getDeterministicColor } from '../../constants';
 import { useGameStore } from '../../store/useGameStore';
 import { DEFAULT_AVATAR_CONFIG } from '../../types';
 import { usePlayerPhysics } from '../../hooks/usePlayerPhysics';
@@ -49,6 +49,28 @@ export const LocalPlayer = ({
   const isChatFocused = useGameStore((state) => state.isChatFocused);
   const timeLeft = useGameStore((state) => state.timeLeft);
   const occupiedDeskIds = useGameStore((state) => state.occupiedDeskIds);
+  const roomLayout = useGameStore((state) => state.roomLayout);
+
+  // Build AABB collision boxes for each desk based on its current position/rotation
+  const deskBoxes = useMemo(() =>
+    roomLayout
+      .filter((f): f is DeskItem => f.type === 'desk')
+      .map((desk) => {
+        const [x, y, z] = desk.position;
+        const rotY = desk.rotation[1];
+        // Desk tabletop is 2 units wide × 1 unit deep in local space.
+        // Rotate the half-extents to get a world-space AABB.
+        const cosR = Math.abs(Math.cos(rotY));
+        const sinR = Math.abs(Math.sin(rotY));
+        const halfX = 1.0 * cosR + 0.5 * sinR;
+        const halfZ = 1.0 * sinR + 0.5 * cosR;
+        return new THREE.Box3(
+          new THREE.Vector3(x - halfX, y, z - halfZ),
+          new THREE.Vector3(x + halfX, y + 1.0, z + halfZ)
+        );
+      }),
+    [roomLayout]
+  );
 
   const focusProgress = isTimerActive ? 1 - timeLeft / (25 * 60) : 0;
   const sessionPaper = useGameStore((state) => state.sessionPaper);
@@ -74,7 +96,7 @@ export const LocalPlayer = ({
 
     // Eject player from chair when session ends
     if (wasTimerActiveRef.current && !isTimerActive && lastActiveDeskIdRef.current) {
-      const desk = DESKS.find((d) => d.id === lastActiveDeskIdRef.current);
+      const desk = roomLayout.find((d) => d.id === lastActiveDeskIdRef.current);
       if (desk) {
         const chairDir = new THREE.Vector3(0, 0, 1).applyAxisAngle(new THREE.Vector3(0, 1, 0), desk.rotation[1]);
         const ejectedPos: [number, number, number] = [
@@ -109,7 +131,7 @@ export const LocalPlayer = ({
 
     // Lock to desk chair during focus session
     if (isTimerActive && activeDeskId) {
-      const desk = DESKS.find((d) => d.id === activeDeskId);
+      const desk = roomLayout.find((d) => d.id === activeDeskId);
       if (desk) {
         const chairOffset = new THREE.Vector3(0, 0, 0.8).applyAxisAngle(
           new THREE.Vector3(0, 1, 0),
@@ -150,7 +172,7 @@ export const LocalPlayer = ({
     let newPosition: [number, number, number] = [...position];
     let newRotation: [number, number, number] = [...rotation];
 
-    newPosition[1] = physics.applyGravity(newPosition, delta);
+    newPosition[1] = physics.applyGravity(newPosition, delta, deskBoxes);
 
     // Camera-relative movement vector
     const cameraDir = new THREE.Vector3();
@@ -168,7 +190,7 @@ export const LocalPlayer = ({
     if (right && !physics.isRolling.current) moveVector.sub(cameraSide);
 
     if (moveVector.length() > 0) {
-      newPosition = physics.applyMovement(newPosition, moveVector, speed, players);
+      newPosition = physics.applyMovement(newPosition, moveVector, speed, players, deskBoxes);
       newRotation[1] = Math.atan2(moveVector.x, moveVector.z);
     }
 

--- a/src/components/ui/HUDPanel.tsx
+++ b/src/components/ui/HUDPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Users, Monitor, Coffee, Briefcase, LogOut } from 'lucide-react';
+import { Users, Monitor, Coffee, Briefcase, LogOut, Layout } from 'lucide-react';
 
 interface HUDPanelProps {
   playerCount: number;
@@ -7,6 +7,7 @@ interface HUDPanelProps {
   currentRoom: string;
   paperReams: number;
   onExitRoom: () => void;
+  onCustomizeOffice: () => void;
 }
 
 export const HUDPanel = ({
@@ -15,6 +16,7 @@ export const HUDPanel = ({
   currentRoom,
   paperReams,
   onExitRoom,
+  onCustomizeOffice,
 }: HUDPanelProps) => (
   <div className="flex flex-col gap-4">
     <div className="bg-white/10 backdrop-blur-md border border-white/20 p-6 rounded-2xl shadow-2xl max-w-xs">
@@ -53,7 +55,14 @@ export const HUDPanel = ({
         </div>
       </div>
 
-      <div className="mt-6 pt-6 border-t border-white/10">
+      <div className="mt-6 pt-6 border-t border-white/10 flex flex-col gap-2">
+        <button
+          onClick={onCustomizeOffice}
+          className="w-full bg-amber-500/20 hover:bg-amber-500/40 border border-amber-500/50 text-amber-200 px-4 py-2 rounded-xl text-xs font-bold transition-all flex items-center justify-center gap-2"
+        >
+          <Layout className="w-3 h-3" />
+          Customize Office
+        </button>
         <button
           onClick={onExitRoom}
           className="w-full bg-indigo-500/20 hover:bg-indigo-500/40 border border-indigo-500/50 text-indigo-200 px-4 py-2 rounded-xl text-xs font-bold transition-all flex items-center justify-center gap-2"

--- a/src/components/ui/OfficeCustomizationPage.tsx
+++ b/src/components/ui/OfficeCustomizationPage.tsx
@@ -1,0 +1,286 @@
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import { motion } from 'motion/react';
+import { FurnitureItem, DeskItem } from '../../types';
+import { getDeterministicColor } from '../../constants';
+import { PixelBeet } from './LandingPage';
+
+const SVG_SIZE = 600;
+const WORLD_SIZE = 50; // -25 to +25
+
+function worldToSvg(worldX: number, worldZ: number): [number, number] {
+  return [
+    ((worldX + 25) / WORLD_SIZE) * SVG_SIZE,
+    ((worldZ + 25) / WORLD_SIZE) * SVG_SIZE,
+  ];
+}
+
+function svgToWorld(svgX: number, svgY: number): [number, number] {
+  return [
+    (svgX / SVG_SIZE) * WORLD_SIZE - 25,
+    (svgY / SVG_SIZE) * WORLD_SIZE - 25,
+  ];
+}
+
+function snap(val: number): number {
+  return Math.round(val * 2) / 2;
+}
+
+const ROOM_RECTS = [
+  { label: "Beet Farm",         x: 36,  y: 36,  w: 108, h: 108, color: '#fef3c7' },
+  { label: "Michael's Office",  x: 420, y: 36,  w: 120, h: 144, color: '#e2e8f0' },
+  { label: "Conference Room",   x: 420, y: 360, w: 120, h: 120, color: '#dbeafe' },
+  { label: "Break Room",        x: 60,  y: 420, w: 120, h: 120, color: '#d1fae5' },
+];
+
+interface DragState {
+  deskId: string;
+  startClientX: number;
+  startClientY: number;
+  startWorldX: number;
+  startWorldZ: number;
+}
+
+interface OfficeCustomizationPageProps {
+  roomId: string;
+  initialLayout: FurnitureItem[];
+  onBack: () => void;
+  onSave: (layout: FurnitureItem[]) => Promise<void>;
+}
+
+export const OfficeCustomizationPage = ({
+  roomId,
+  initialLayout,
+  onBack,
+  onSave,
+}: OfficeCustomizationPageProps) => {
+  const [layout, setLayout] = useState<FurnitureItem[]>(initialLayout);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const dragging = useRef<DragState | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const desks = layout.filter((f): f is DeskItem => f.type === 'desk');
+  const hasChanges = JSON.stringify(layout) !== JSON.stringify(initialLayout);
+
+  const handleSave = async () => {
+    setSaving(true);
+    await onSave(layout);
+    setSaving(false);
+  };
+
+  const handleBack = () => {
+    if (hasChanges && !confirm('You have unsaved changes. Discard them?')) return;
+    onBack();
+  };
+
+  const handleDeskMouseDown = useCallback((e: React.MouseEvent, desk: DeskItem) => {
+    e.stopPropagation();
+    setSelectedId(desk.id);
+    dragging.current = {
+      deskId: desk.id,
+      startClientX: e.clientX,
+      startClientY: e.clientY,
+      startWorldX: desk.position[0],
+      startWorldZ: desk.position[2],
+    };
+  }, []);
+
+  const handleSvgMouseMove = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+    if (!dragging.current || !svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const scale = SVG_SIZE / rect.width;
+    const deltaClientX = (e.clientX - dragging.current.startClientX) * scale;
+    const deltaClientY = (e.clientY - dragging.current.startClientY) * scale;
+    const [deltaWorldX, deltaWorldZ] = svgToWorld(deltaClientX, deltaClientY).map((v) => v + 25) as [number, number];
+
+    const newWorldX = snap(dragging.current.startWorldX + deltaWorldX);
+    const newWorldZ = snap(dragging.current.startWorldZ + deltaWorldZ);
+    const clampedX = Math.max(-24, Math.min(24, newWorldX));
+    const clampedZ = Math.max(-24, Math.min(24, newWorldZ));
+
+    setLayout((prev) =>
+      prev.map((f) =>
+        f.id === dragging.current!.deskId
+          ? { ...f, position: [clampedX, f.position[1], clampedZ] as [number, number, number] }
+          : f
+      )
+    );
+  }, []);
+
+  const handleRotate = useCallback((deskId: string, direction: 1 | -1) => {
+    setLayout((prev) =>
+      prev.map((f) =>
+        f.id === deskId
+          ? { ...f, rotation: [f.rotation[0], f.rotation[1] + direction * (Math.PI / 4), f.rotation[2]] as [number, number, number] }
+          : f
+      )
+    );
+  }, []);
+
+  useEffect(() => {
+    const stopDrag = () => { dragging.current = null; };
+    window.addEventListener('mouseup', stopDrag);
+    return () => window.removeEventListener('mouseup', stopDrag);
+  }, []);
+
+  const selectedDesk = selectedId ? desks.find((d) => d.id === selectedId) : null;
+
+  return (
+    <div className="min-h-screen bg-[#3d2b1f] flex flex-col items-center justify-center p-4 font-pixel text-white overflow-hidden">
+      {/* Background beets */}
+      <div className="absolute inset-0 opacity-10 pointer-events-none grid grid-cols-6 gap-20 p-10">
+        {Array.from({ length: 24 }).map((_, i) => (
+          <div key={i} className="flex justify-center items-center">
+            <PixelBeet />
+          </div>
+        ))}
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="relative z-10 w-full max-w-3xl"
+      >
+        {/* Header */}
+        <div className="pixel-border bg-[#2d1f0f] p-4 mb-4">
+          <div className="flex items-center justify-between">
+            <button
+              onClick={handleBack}
+              className="pixel-button text-xs px-3 py-2"
+            >
+              ← Back
+            </button>
+            <div className="text-center">
+              <div className="text-lg text-amber-300">OFFICE LAYOUT</div>
+              <div className="text-xs text-amber-500/70">Room: {roomId.toUpperCase()}</div>
+            </div>
+            <button
+              onClick={handleSave}
+              disabled={saving || !hasChanges}
+              className="pixel-button text-xs px-3 py-2 disabled:opacity-50"
+            >
+              {saving ? 'Saving...' : '💾 Save Layout'}
+            </button>
+          </div>
+        </div>
+
+        {/* Floor plan */}
+        <div className="pixel-border bg-[#2d1f0f] p-4 mb-4">
+          <svg
+            ref={svgRef}
+            viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
+            className="w-full border border-amber-900/50 cursor-default select-none"
+            style={{ maxHeight: '60vh', aspectRatio: '1' }}
+            onMouseMove={handleSvgMouseMove}
+          >
+            {/* Floor */}
+            <rect x="0" y="0" width={SVG_SIZE} height={SVG_SIZE} fill="#f5f0e8" />
+
+            {/* Grid lines */}
+            {Array.from({ length: 11 }).map((_, i) => (
+              <React.Fragment key={i}>
+                <line x1={i * 60} y1="0" x2={i * 60} y2={SVG_SIZE} stroke="#e2d8c8" strokeWidth="0.5" />
+                <line x1="0" y1={i * 60} x2={SVG_SIZE} y2={i * 60} stroke="#e2d8c8" strokeWidth="0.5" />
+              </React.Fragment>
+            ))}
+
+            {/* Static room areas */}
+            {ROOM_RECTS.map((r) => (
+              <g key={r.label}>
+                <rect x={r.x} y={r.y} width={r.w} height={r.h} fill={r.color} stroke="#94a3b8" strokeWidth="1.5" opacity="0.85" />
+                <text
+                  x={r.x + r.w / 2}
+                  y={r.y + r.h / 2}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize="9"
+                  fill="#475569"
+                  fontFamily="monospace"
+                >
+                  {r.label}
+                </text>
+              </g>
+            ))}
+
+            {/* Desks */}
+            {desks.map((desk) => {
+              const [sx, sy] = worldToSvg(desk.position[0], desk.position[2]);
+              const rotDeg = -(desk.rotation[1] * 180) / Math.PI;
+              const color = getDeterministicColor(String(desk.config.ownerName));
+              const isSelected = desk.id === selectedId;
+              const label = String(desk.config.ownerName).split(' ')[0];
+
+              return (
+                <g
+                  key={desk.id}
+                  transform={`translate(${sx}, ${sy}) rotate(${rotDeg})`}
+                  onMouseDown={(e) => handleDeskMouseDown(e, desk)}
+                  style={{ cursor: 'grab' }}
+                >
+                  <rect
+                    x="-20"
+                    y="-12"
+                    width="40"
+                    height="24"
+                    fill={color}
+                    fillOpacity="0.8"
+                    stroke={isSelected ? '#111' : '#444'}
+                    strokeWidth={isSelected ? 2.5 : 1}
+                    rx="2"
+                  />
+                  {/* Monitor stub */}
+                  <rect x="-6" y="-11" width="12" height="6" fill="rgba(0,0,0,0.25)" rx="1" />
+                  <text
+                    x="0"
+                    y="0"
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize="8"
+                    fill="white"
+                    fontWeight="bold"
+                    fontFamily="monospace"
+                    transform="rotate(0)"
+                    style={{ pointerEvents: 'none' }}
+                  >
+                    {label}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+
+        {/* Selected desk controls */}
+        <div className="pixel-border bg-[#2d1f0f] p-3 min-h-[56px] flex items-center justify-between">
+          {selectedDesk ? (
+            <>
+              <span className="text-xs text-amber-300">
+                Selected: <span className="text-white">{String(selectedDesk.config.ownerName)}'s Desk</span>
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => handleRotate(selectedDesk.id, -1)}
+                  className="pixel-button text-xs px-3 py-1"
+                  title="Rotate counter-clockwise 45°"
+                >
+                  ↺ CCW
+                </button>
+                <button
+                  onClick={() => handleRotate(selectedDesk.id, 1)}
+                  className="pixel-button text-xs px-3 py-1"
+                  title="Rotate clockwise 45°"
+                >
+                  CW ↻
+                </button>
+              </div>
+            </>
+          ) : (
+            <span className="text-xs text-amber-500/70">
+              Click a desk to select it · Drag to reposition · Changes broadcast live to all players
+            </span>
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/src/components/world/Desk.tsx
+++ b/src/components/world/Desk.tsx
@@ -10,11 +10,13 @@ export const Desk = ({
   position,
   rotation = [0, 0, 0],
   hasChair = true,
+  ownerName,
 }: {
   id: string;
   position: [number, number, number];
   rotation?: [number, number, number];
   hasChair?: boolean;
+  ownerName?: string;
 }) => {
   const setNearestDeskId = useGameStore((state) => state.setNearestDeskId);
   const nearestDeskId = useGameStore((state) => state.nearestDeskId);
@@ -40,6 +42,18 @@ export const Desk = ({
 
   return (
     <group ref={deskRef} position={position} rotation={rotation}>
+      {ownerName && (
+        <Billboard position={[0, 1.8, 0]}>
+          <Text
+            fontSize={0.18}
+            color="#fde68a"
+            outlineColor="black"
+            outlineWidth={0.02}
+          >
+            {ownerName}
+          </Text>
+        </Billboard>
+      )}
       {isNearest && !isTimerActive && (
         <Billboard position={[0, 2.5, 0]}>
           <Text

--- a/src/components/world/OfficeEnvironment.tsx
+++ b/src/components/world/OfficeEnvironment.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { Box, Plane, Text } from '@react-three/drei';
-import { DESKS } from '../../constants';
 import { Chair } from './Chair';
 import { Desk } from './Desk';
 import { BeetFarm } from './BeetFarm';
 import { Banner } from './Banner';
+import { useGameStore } from '../../store/useGameStore';
+import { DeskItem } from '../../types';
 
-export const OfficeEnvironment = () => (
+export const OfficeEnvironment = () => {
+  const desks = useGameStore((s) => s.roomLayout).filter((f): f is DeskItem => f.type === 'desk');
+  return (
   <group>
     {/* Floor */}
     <Plane args={[50, 50]} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0, 0]}>
@@ -33,8 +36,8 @@ export const OfficeEnvironment = () => (
     </Box>
 
     {/* Desks */}
-    {DESKS.map((desk) => (
-      <Desk key={desk.id} {...desk} />
+    {desks.map((desk) => (
+      <Desk key={desk.id} id={desk.id} position={desk.position} rotation={desk.rotation} ownerName={String(desk.config.ownerName)} />
     ))}
 
     <Banner position={[-3.5, 6, -6]} />
@@ -112,4 +115,5 @@ export const OfficeEnvironment = () => (
 
     <BeetFarm position={[-18, 0, -18]} />
   </group>
-);
+  );
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,20 +29,6 @@ export const DESKS = [
 ];
 
 export const COLLISION_BOXES = [
-  // Desks (Axis-aligned or approximated)
-  new THREE.Box3(new THREE.Vector3(-10.6, 0, -16.1), new THREE.Vector3(-9.4, 1.0, -13.9)), // Pam's Desk (1x2 rotated)
-  new THREE.Box3(new THREE.Vector3(-6.1, 0, -5.6), new THREE.Vector3(-3.9, 1.0, -4.4)),
-  new THREE.Box3(new THREE.Vector3(-6.1, 0, -7.6), new THREE.Vector3(-3.9, 1.0, -6.4)),
-  new THREE.Box3(new THREE.Vector3(-3.1, 0, -5.6), new THREE.Vector3(-0.9, 1.0, -4.4)),
-  new THREE.Box3(new THREE.Vector3(-3.1, 0, -7.6), new THREE.Vector3(-0.9, 1.0, -6.4)),
-  
-  // Sales Team Chairs
-  new THREE.Box3(new THREE.Vector3(-11.1, 0, -15.3), new THREE.Vector3(-10.5, 0.5, -14.7)), // Pam's Chair
-  new THREE.Box3(new THREE.Vector3(-5.3, 0, -4.5), new THREE.Vector3(-4.7, 0.5, -3.9)),
-  new THREE.Box3(new THREE.Vector3(-5.3, 0, -8.1), new THREE.Vector3(-4.7, 0.5, -7.5)),
-  new THREE.Box3(new THREE.Vector3(-2.3, 0, -4.5), new THREE.Vector3(-1.7, 0.5, -3.9)),
-  new THREE.Box3(new THREE.Vector3(-2.3, 0, -8.1), new THREE.Vector3(-1.7, 0.5, -7.5)),
-  
   // Michael's Office Walls & Desk
   new THREE.Box3(new THREE.Vector3(10, 0, -10.1), new THREE.Vector3(20, 8, -9.9)), // Wall 1
   new THREE.Box3(new THREE.Vector3(9.9, 0, -20), new THREE.Vector3(10.1, 8, -10)), // Wall 2

--- a/src/hooks/usePlayerPhysics.ts
+++ b/src/hooks/usePlayerPhysics.ts
@@ -62,9 +62,10 @@ export function usePlayerPhysics() {
   }
 
   // Returns the new Y position after applying gravity and landing
-  function applyGravity(position: [number, number, number], delta: number): number {
+  function applyGravity(position: [number, number, number], delta: number, extraBoxes: THREE.Box3[] = []): number {
     let groundY = 0;
-    for (const box of COLLISION_BOXES) {
+    const allBoxes = extraBoxes.length > 0 ? [...COLLISION_BOXES, ...extraBoxes] : COLLISION_BOXES;
+    for (const box of allBoxes) {
       if (
         position[0] >= box.min.x && position[0] <= box.max.x &&
         position[2] >= box.min.z && position[2] <= box.max.z &&
@@ -102,7 +103,8 @@ export function usePlayerPhysics() {
     position: [number, number, number],
     moveVector: THREE.Vector3,
     speed: number,
-    otherPlayers: Record<string, Player>
+    otherPlayers: Record<string, Player>,
+    extraBoxes: THREE.Box3[] = []
   ): [number, number, number] {
     if (moveVector.length() === 0) return position;
 
@@ -111,11 +113,11 @@ export function usePlayerPhysics() {
 
     const testX = [...newPos] as [number, number, number];
     testX[0] += scaled.x;
-    if (!hasCollision(testX, otherPlayers)) newPos[0] = testX[0];
+    if (!hasCollision(testX, otherPlayers, extraBoxes)) newPos[0] = testX[0];
 
     const testZ = [...newPos] as [number, number, number];
     testZ[2] += scaled.z;
-    if (!hasCollision(testZ, otherPlayers)) newPos[2] = testZ[2];
+    if (!hasCollision(testZ, otherPlayers, extraBoxes)) newPos[2] = testZ[2];
 
     return newPos;
   }
@@ -132,13 +134,14 @@ export function usePlayerPhysics() {
   };
 }
 
-function hasCollision(position: [number, number, number], otherPlayers: Record<string, Player>): boolean {
+function hasCollision(position: [number, number, number], otherPlayers: Record<string, Player>, extraBoxes: THREE.Box3[] = []): boolean {
   const playerBox = new THREE.Box3().setFromCenterAndSize(
     new THREE.Vector3(position[0], position[1] + 0.8, position[2]),
     new THREE.Vector3(0.5, 1.4, 0.5)
   );
 
-  for (const box of COLLISION_BOXES) {
+  const allBoxes = extraBoxes.length > 0 ? [...COLLISION_BOXES, ...extraBoxes] : COLLISION_BOXES;
+  for (const box of allBoxes) {
     if (playerBox.intersectsBox(box)) return true;
   }
 

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { io, Socket } from 'socket.io-client';
-import { Player, ChatMessage, AvatarConfig } from '../types';
+import { Player, ChatMessage, AvatarConfig, FurnitureItem } from '../types';
 import { AuthUser } from './useAuth';
 import { useGameStore } from '../store/useGameStore';
 
@@ -107,6 +107,14 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
 
     newSocket.on('avatarConfigLoaded', (config: AvatarConfig) => {
       useGameStore.getState().setAvatarConfig(config);
+    });
+
+    newSocket.on('roomLayoutLoaded', (layout: FurnitureItem[]) => {
+      useGameStore.getState().setRoomLayout(layout);
+    });
+
+    newSocket.on('roomLayoutUpdated', (layout: FurnitureItem[]) => {
+      useGameStore.getState().setRoomLayout(layout);
     });
 
     // Sync paper reams to server whenever the count changes

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { AvatarConfig, DEFAULT_AVATAR_CONFIG } from '../types';
+import { AvatarConfig, DEFAULT_AVATAR_CONFIG, FurnitureItem } from '../types';
 
 interface GameState {
   // Paper Clicker State
@@ -32,6 +32,8 @@ interface GameState {
   setOccupiedDeskIds: (ids: string[]) => void;
   setUser: (user: { id: string, email: string, name: string, picture: string } | null) => void;
   setAvatarConfig: (config: AvatarConfig) => void;
+  roomLayout: FurnitureItem[];
+  setRoomLayout: (layout: FurnitureItem[]) => void;
 }
 
 export const useGameStore = create<GameState>((set) => ({
@@ -105,4 +107,6 @@ export const useGameStore = create<GameState>((set) => ({
     localStorage.setItem('avatar_config', JSON.stringify(config));
     set({ avatarConfig: config });
   },
+  roomLayout: [],
+  setRoomLayout: (layout) => set({ roomLayout: layout }),
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,19 @@ export interface Player {
   avatarConfig?: AvatarConfig;
 }
 
+export interface FurnitureItem {
+  id: string;
+  type: string;
+  position: [number, number, number];
+  rotation: [number, number, number];
+  config: Record<string, unknown>;
+}
+
+export interface DeskItem extends FurnitureItem {
+  type: 'desk';
+  config: { ownerEmail: string; ownerName: string; model?: string; [key: string]: unknown };
+}
+
 export interface ChatMessage {
   id: string;
   playerId: string;


### PR DESCRIPTION
- Every player is auto-assigned a persistent desk on first room join, stored in a new `room_layouts` PostgreSQL table (JSONB, per-room)
- New `FurnitureItem` / `DeskItem` type system is extensible to future furniture types with no DB schema changes required
- "Customize Office" button in HUD opens a top-down 2D SVG editor where desks can be dragged and rotated; saving broadcasts the new layout to all players in the room via Socket.IO
- Desk name labels (owner's name) rendered as always-visible billboards in the 3D world above each desk
- Collision boxes are now dynamic: hardcoded desk boxes removed from constants, replaced by AABB boxes computed from live desk positions and passed through the physics hook at runtime