### PR TITLE
fix: sync held throwables to other players (fixes #23)

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,7 @@ import {
   WATER_COOLER_WORLD_POSITION,
   WATER_COOLER_RADIUS,
 } from "./src/officeLayout.js";
+import { isAllowedHeldThrowableId } from "./src/networkThrowables.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -686,6 +687,7 @@ io.on("connection", (socket) => {
         name: name,
         room: room,
         wornPropId: null,
+        heldThrowableId: null,
       };
 
       // Remove stale entries for the same email before sending currentPlayers.
@@ -774,6 +776,24 @@ io.on("connection", (socket) => {
       const pid = data?.propId ?? null;
       if (pid !== null && pid !== "ms_body") return;
       rooms[playerRoom][socket.id].wornPropId = pid;
+      if (pid !== null) {
+        rooms[playerRoom][socket.id].heldThrowableId = null;
+      }
+      socket.to(playerRoom).emit("playerMoved", rooms[playerRoom][socket.id]);
+    });
+
+    socket.on("playerHeldThrowable", (data: { propId: string | null }) => {
+      let playerRoom = "";
+      for (const roomId in rooms) {
+        if (rooms[roomId][socket.id]) {
+          playerRoom = roomId;
+          break;
+        }
+      }
+      if (!playerRoom || !rooms[playerRoom][socket.id]) return;
+      const propId = data?.propId ?? null;
+      if (!isAllowedHeldThrowableId(propId)) return;
+      rooms[playerRoom][socket.id].heldThrowableId = propId;
       socket.to(playerRoom).emit("playerMoved", rooms[playerRoom][socket.id]);
     });
 

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -13,6 +13,10 @@ import { CharacterAvatar } from './CharacterAvatar';
 import { WaterEnergyAura } from './WaterEnergyAura';
 import { ChatBubble } from '../ui/ChatBubble';
 
+function emitHeldThrowableSync(socket: Socket | null, propId: string | null) {
+  if (socket?.connected) socket.emit('playerHeldThrowable', { propId });
+}
+
 const BOUNDS = 22;
 const CAMERA_BOUNDS = 22;
 // Camera is clamped within this radius of the player to prevent wall-clipping
@@ -175,6 +179,7 @@ export const LocalPlayer = ({
       } else if (heldObjectId !== null) {
         if (heldObjectId === MS_BODY_THROWABLE_ID) {
           wearHeldProp(MS_BODY_THROWABLE_ID);
+          emitHeldThrowableSync(socket, null);
           socket?.emit('playerWornProp', { propId: MS_BODY_THROWABLE_ID });
           socket?.connected &&
             socket.emit(
@@ -183,10 +188,12 @@ export const LocalPlayer = ({
             );
         } else {
           dropObject();
+          emitHeldThrowableSync(socket, null);
         }
         interactConsumed = true;
       } else if (nearThrowableId !== null) {
         pickUpObject(nearThrowableId);
+        emitHeldThrowableSync(socket, nearThrowableId);
         interactConsumed = true;
       }
     }
@@ -197,6 +204,7 @@ export const LocalPlayer = ({
       if (heldObjectId !== null) {
         if (heldObjectId === MS_BODY_THROWABLE_ID) {
           dropObject();
+          emitHeldThrowableSync(socket, null);
           const feet: [number, number, number] = [positionRef.current[0], 0.15, positionRef.current[2]];
           const rot: [number, number, number] = [0, rotationRef.current[1], 0];
           socket?.emit('throwableRestSync', {
@@ -210,6 +218,7 @@ export const LocalPlayer = ({
           camDir.y = 0;
           camDir.normalize();
           throwObject([camDir.x * 10, 5, camDir.z * 10]);
+          emitHeldThrowableSync(socket, null);
         }
       }
     }

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -5,6 +5,7 @@ import * as THREE from 'three';
 import { Player, DEFAULT_AVATAR_CONFIG } from '../../types';
 import { MS_BODY_THROWABLE_ID } from '../../propIds';
 import { CharacterAvatar } from './CharacterAvatar';
+import { OtherPlayerHeldThrowable } from './OtherPlayerHeldThrowable';
 import { ChatBubble } from '../ui/ChatBubble';
 
 export const OtherPlayer = ({ player }: { player: Player }) => {
@@ -20,6 +21,7 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
   return (
     <group position={player.position} rotation={[0, player.rotation[1], 0]}>
       <group rotation={[player.isRolling ? -Math.PI * 2 * ((player.rollTimer || 0) / 0.5) : 0, 0, 0]}>
+        <OtherPlayerHeldThrowable heldThrowableId={player.heldThrowableId} />
         <CharacterAvatar
           color={player.avatarConfig?.shirtColor ?? player.color}
           isMoving={isMoving}

--- a/src/components/player/OtherPlayerHeldThrowable.tsx
+++ b/src/components/player/OtherPlayerHeldThrowable.tsx
@@ -1,0 +1,28 @@
+import React, { Suspense } from 'react';
+import { useGameAsset, type AssetKey } from '../../hooks/useGameAsset';
+import { heldThrowableIdToDisplay, type NetworkHeldThrowableId } from '../../networkThrowables';
+
+function HeldClone({ assetKey, scale }: { assetKey: AssetKey; scale: number }) {
+  const { scene } = useGameAsset(assetKey);
+  return <primitive object={scene.clone()} scale={scale} />;
+}
+
+/** Renders another player's held throwable at the same offset as local `useThrowable` held phase.
+ * Must live under `OtherPlayer`'s yaw group: parent already applies `rotationY`, so use local +Z forward only. */
+export function OtherPlayerHeldThrowable({
+  heldThrowableId,
+}: {
+  heldThrowableId: string | null | undefined;
+}) {
+  if (!heldThrowableId) return null;
+  const spec = heldThrowableIdToDisplay[heldThrowableId as NetworkHeldThrowableId];
+  if (!spec) return null;
+
+  return (
+    <group position={[0, 0.9, 0.6]}>
+      <Suspense fallback={null}>
+        <HeldClone assetKey={spec.assetKey} scale={spec.scale} />
+      </Suspense>
+    </group>
+  );
+}

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -25,9 +25,18 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
     useGameStore.getState().setRemoteWornThrowableIds(worn);
   };
 
+  const syncRemoteHeldThrowableIds = (playerMap: Record<string, Player>) => {
+    const held: string[] = [];
+    for (const p of Object.values(playerMap)) {
+      if (p.heldThrowableId) held.push(p.heldThrowableId);
+    }
+    useGameStore.getState().setRemoteHeldThrowableIds(held);
+  };
+
   const syncFromPlayerMap = (playerMap: Record<string, Player>) => {
     syncOccupiedDesks(playerMap);
     syncRemoteWornThrowableIds(playerMap);
+    syncRemoteHeldThrowableIds(playerMap);
   };
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
   const [lastLocalMessage, setLastLocalMessage] = useState<{ text: string; time: number } | null>(null);

--- a/src/hooks/useThrowable.ts
+++ b/src/hooks/useThrowable.ts
@@ -131,7 +131,8 @@ export function useThrowable({
     if (!groupRef.current) return;
 
     const store = useGameStore.getState();
-    const { heldObjectId, throwVelocity, wornPropId, remoteWornThrowableIds } = store;
+    const { heldObjectId, throwVelocity, wornPropId, remoteWornThrowableIds, remoteHeldThrowableIds } =
+      store;
 
     const playerGroup = rfState.scene.getObjectByName('localPlayer');
     const playerPos = new THREE.Vector3();
@@ -143,6 +144,11 @@ export function useThrowable({
       wornPropId !== id &&
       phaseRef.current !== 'held' &&
       phaseRef.current !== 'worn';
+
+    const hiddenBecauseHeldElsewhere =
+      remoteHeldThrowableIds.includes(id) &&
+      heldObjectId !== id &&
+      phaseRef.current === 'idle';
 
     // ── Transitions ───────────────────────────────────────────────────────
 
@@ -201,7 +207,7 @@ export function useThrowable({
       posRef.current.copy(restPosRef.current);
       groupRef.current.rotation.copy(restRotRef.current);
 
-      if (hiddenBecauseWornElsewhere) {
+      if (hiddenBecauseWornElsewhere || hiddenBecauseHeldElsewhere) {
         groupRef.current.visible = false;
         if (store.nearThrowableId === id) store.setNearThrowable(null);
       } else {

--- a/src/networkThrowables.ts
+++ b/src/networkThrowables.ts
@@ -1,0 +1,22 @@
+import type { AssetKey } from './hooks/useGameAsset';
+
+/** Throwable ids allowed for `playerHeldThrowable` sync (must match scene `ThrowableObject` ids). */
+export const NETWORK_HELD_THROWABLE_IDS = ['ms_body', 'dundie', 'dwight_bobblehead'] as const;
+export type NetworkHeldThrowableId = (typeof NETWORK_HELD_THROWABLE_IDS)[number];
+
+const ID_SET = new Set<string>(NETWORK_HELD_THROWABLE_IDS);
+
+/** `null` clears held state; non-null must be in `NETWORK_HELD_THROWABLE_IDS`. */
+export function isAllowedHeldThrowableId(id: string | null): boolean {
+  if (id === null) return true;
+  return ID_SET.has(id);
+}
+
+export const heldThrowableIdToDisplay: Record<
+  NetworkHeldThrowableId,
+  { assetKey: AssetKey; scale: number }
+> = {
+  ms_body: { assetKey: 'ms_body', scale: 0.4 },
+  dundie: { assetKey: 'dundie', scale: 0.45 },
+  dwight_bobblehead: { assetKey: 'dwight_bobblehead', scale: 0.45 },
+};

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -77,6 +77,10 @@ interface GameState {
   remoteWornThrowableIds: string[];
   setRemoteWornThrowableIds: (ids: string[]) => void;
 
+  /** Throwable ids held by *other* players — hides world copies; used for remote held mesh. */
+  remoteHeldThrowableIds: string[];
+  setRemoteHeldThrowableIds: (ids: string[]) => void;
+
   /** Last known rest pose for a throwable (synced when someone drops / removes wear). */
   throwableRest: Partial<
     Record<string, { position: [number, number, number]; rotation: [number, number, number] }>
@@ -200,6 +204,9 @@ export const useGameStore = create<GameState>((set) => ({
 
   remoteWornThrowableIds: [],
   setRemoteWornThrowableIds: (ids) => set({ remoteWornThrowableIds: ids }),
+
+  remoteHeldThrowableIds: [],
+  setRemoteHeldThrowableIds: (ids) => set({ remoteHeldThrowableIds: ids }),
 
   throwableRest: {},
   setThrowableRest: (id, position, rotation) =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export interface Player {
   avatarConfig?: AvatarConfig;
   /** Prop id from ThrowableObject (e.g. ms_body) worn on the torso; synced for multiplayer. */
   wornPropId?: string | null;
+  /** Throwable id currently held in hands; synced for multiplayer. */
+  heldThrowableId?: string | null;
 }
 
 export interface FurnitureItem {


### PR DESCRIPTION
## Summary

Fixes [#23](https://github.com/okg00dbye/schrute-space/issues/23): when a player **holds** a throwable, other clients did not show that object. **Wearable** props were already synced; this change applies the same idea to the held (pickup) state.

## What changed

- **Client → server:** `LocalPlayer` emits `playerHeldThrowable` with the current prop id (or `null` when dropped), aligned with `useThrowable` pickup/drop.
- **Server:** `heldThrowableId` is stored on each room player, cleared on disconnect, and included in movement/state updates so every peer receives it.
- **Remote render:** New `OtherPlayerHeldThrowable` clones the same GLTF assets and uses the same local offset as the local held phase (under the other player’s yaw group).
- **Allowlist:** `networkThrowables.ts` defines which ids are valid for sync and maps them to `AssetKey` + scale (must stay in sync with scene `ThrowableObject` ids).

## How to verify

1. Two browsers (or two profiles) in the same room.
2. Player A picks up a throwable (e.g. Dundie, bobblehead, etc.).
3. Player B should see the object in A’s hands at the expected position; dropping it should clear it for B.

<img width="229" height="250" alt="image" src="https://github.com/user-attachments/assets/424d3af6-7e8d-4143-845d-bb975c3be45a" />