### PR TITLE
fix: world prompt depth + avatar physics React sync

### DIFF
--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -7,7 +7,7 @@ import { Player, DeskItem } from '../../types';
 import { getDeterministicColor, COLLISION_BOXES } from '../../constants';
 import { useGameStore } from '../../store/useGameStore';
 import { DEFAULT_AVATAR_CONFIG } from '../../types';
-import { usePlayerPhysics } from '../../hooks/usePlayerPhysics';
+import { usePlayerPhysics, usePlayerPhysicsAvatarSync } from '../../hooks/usePlayerPhysics';
 import { MS_BODY_THROWABLE_ID } from '../../propIds';
 import { CharacterAvatar } from './CharacterAvatar';
 import { WaterEnergyAura } from './WaterEnergyAura';
@@ -55,6 +55,7 @@ export const LocalPlayer = ({
   const avatarConfig = useGameStore((state) => state.avatarConfig);
   const playerColor = avatarConfig?.shirtColor ?? getDeterministicColor(playerName);
   const physics = usePlayerPhysics();
+  const avatarPhysics = usePlayerPhysicsAvatarSync(physics);
 
   const nearestDeskId = useGameStore((state) => state.nearestDeskId);
   const activeDeskId = useGameStore((state) => state.activeDeskId);
@@ -416,8 +417,8 @@ export const LocalPlayer = ({
           <CharacterAvatar
             color={playerColor}
             isMoving={isMoving}
-            isGrounded={physics.isGrounded.current}
-            isRolling={physics.isRolling.current}
+            isGrounded={avatarPhysics.grounded}
+            isRolling={avatarPhysics.rolling}
             skinTone={avatarConfig?.skinTone ?? DEFAULT_AVATAR_CONFIG.skinTone}
             pantColor={avatarConfig?.pantColor ?? DEFAULT_AVATAR_CONFIG.pantColor}
             wornUpperPropId={wornPropId === MS_BODY_THROWABLE_ID ? MS_BODY_THROWABLE_ID : null}

--- a/src/components/world/ThrowableObject.tsx
+++ b/src/components/world/ThrowableObject.tsx
@@ -15,6 +15,7 @@
 import React from 'react';
 import { Billboard, Text } from '@react-three/drei';
 import { useThrowable } from '../../hooks/useThrowable';
+import { onOverlayTextSync } from '../../utils/overlayTextSync';
 
 interface ThrowableObjectProps {
   id: string;
@@ -65,6 +66,7 @@ export function ThrowableObject({
             anchorY="middle"
             outlineWidth={0.012}
             outlineColor="black"
+            onSync={onOverlayTextSync}
           >
             {label}
           </Text>
@@ -81,6 +83,7 @@ export function ThrowableObject({
             anchorY="middle"
             outlineWidth={0.01}
             outlineColor="black"
+            onSync={onOverlayTextSync}
           >
             [E] Pick Up    [F] Inspect
           </Text>
@@ -96,6 +99,7 @@ export function ThrowableObject({
             anchorY="middle"
             outlineWidth={0.01}
             outlineColor="black"
+            onSync={onOverlayTextSync}
           >
             {wearable ? '[E] Wear    [G] Put Down' : '[E] Put Down    [G] Throw'}
           </Text>

--- a/src/components/world/break-room/props/WaterCooler.tsx
+++ b/src/components/world/break-room/props/WaterCooler.tsx
@@ -4,6 +4,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { WATER_COOLER_RADIUS } from '../../../../officeLayout';
 import { useGameStore } from '../../../../store/useGameStore';
+import { onOverlayTextSync } from '../../../../utils/overlayTextSync';
 
 const FIVE_MIN_MS = 5 * 60 * 1000;
 
@@ -52,6 +53,7 @@ export const WaterCooler = ({
             color="#7dd3fc"
             outlineColor="black"
             outlineWidth={0.02}
+            onSync={onOverlayTextSync}
           >
             Water cooler gossip time
           </Text>

--- a/src/components/world/conference-room/props/Whiteboard.tsx
+++ b/src/components/world/conference-room/props/Whiteboard.tsx
@@ -3,6 +3,7 @@ import { Box, Cylinder, Billboard, Text } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useGameStore } from '../../../../store/useGameStore';
+import { onOverlayTextSync } from '../../../../utils/overlayTextSync';
 
 interface WhiteboardProps {
   position: [number, number, number];
@@ -131,7 +132,13 @@ export const Whiteboard = ({ position, rotation = [0, 0, 0] }: WhiteboardProps) 
       {/* Proximity prompt */}
       {nearWhiteboard && (
         <Billboard position={[0, 2.5, 0]}>
-          <Text fontSize={0.2} color="white" outlineColor="black" outlineWidth={0.02}>
+          <Text
+            fontSize={0.2}
+            color="white"
+            outlineColor="black"
+            outlineWidth={0.02}
+            onSync={onOverlayTextSync}
+          >
             Press [E] to View Leaderboard
           </Text>
         </Billboard>

--- a/src/components/world/working-area/Desk.tsx
+++ b/src/components/world/working-area/Desk.tsx
@@ -4,6 +4,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useGameStore } from '../../../store/useGameStore';
 import { Chair } from '../shared/props/Chair';
+import { onOverlayTextSync } from '../../../utils/overlayTextSync';
 
 export const Desk = ({
   id,
@@ -56,6 +57,7 @@ export const Desk = ({
             color="#fde68a"
             outlineColor="black"
             outlineWidth={0.02}
+            onSync={onOverlayTextSync}
           >
             {ownerName}
           </Text>
@@ -68,6 +70,7 @@ export const Desk = ({
             color={isOccupied ? '#f87171' : 'white'}
             outlineColor="black"
             outlineWidth={0.02}
+            onSync={onOverlayTextSync}
           >
             {isOccupied ? 'Desk Occupied' : 'Press [E] to Start Focus'}
           </Text>
@@ -78,6 +81,7 @@ export const Desk = ({
               outlineColor="black"
               outlineWidth={0.02}
               position={[0, -0.28, 0]}
+              onSync={onOverlayTextSync}
             >
               Press [F] to Use Computer
             </Text>

--- a/src/hooks/usePlayerPhysics.ts
+++ b/src/hooks/usePlayerPhysics.ts
@@ -1,7 +1,13 @@
-import { useRef } from 'react';
+import { useRef, useCallback, useSyncExternalStore } from 'react';
 import * as THREE from 'three';
 import { COLLISION_BOXES } from '../constants';
 import { Player } from '../types';
+
+/** Values derived from physics refs that must trigger React re-renders (refs alone do not). */
+export type PlayerPhysicsAvatarSnapshot = Readonly<{
+  grounded: boolean;
+  rolling: boolean;
+}>;
 
 // Pre-allocated objects to avoid per-frame GC pressure
 const _playerBox = new THREE.Box3();
@@ -27,6 +33,27 @@ export function usePlayerPhysics() {
   const prevJumpPressed = useRef(false);
   const prevForwardPressed = useRef(false);
 
+  const avatarSnapshotRef = useRef<PlayerPhysicsAvatarSnapshot>({ grounded: true, rolling: false });
+  const avatarListenersRef = useRef(new Set<() => void>());
+
+  function pushAvatarSnapshot() {
+    const g = isGrounded.current;
+    const r = isRolling.current;
+    const s = avatarSnapshotRef.current;
+    if (s.grounded === g && s.rolling === r) return;
+    avatarSnapshotRef.current = { grounded: g, rolling: r };
+    avatarListenersRef.current.forEach((l) => l());
+  }
+
+  const subscribeAvatar = useCallback((onStoreChange: () => void) => {
+    avatarListenersRef.current.add(onStoreChange);
+    return () => {
+      avatarListenersRef.current.delete(onStoreChange);
+    };
+  }, []);
+
+  const getAvatarSnapshot = useCallback(() => avatarSnapshotRef.current, []);
+
   function processJump(jump: boolean, onDoubleJump?: () => void) {
     const justPressed = jump && !prevJumpPressed.current;
     prevJumpPressed.current = jump;
@@ -44,6 +71,7 @@ export function usePlayerPhysics() {
       onDoubleJump?.();
     }
     lastJumpTime.current = now;
+    pushAvatarSnapshot();
   }
 
   function processRoll(forward: boolean, onRoll?: () => void) {
@@ -59,6 +87,7 @@ export function usePlayerPhysics() {
       onRoll?.();
     }
     lastForwardTime.current = now;
+    pushAvatarSnapshot();
   }
 
   function tickRoll(delta: number) {
@@ -66,6 +95,7 @@ export function usePlayerPhysics() {
       rollTimer.current -= delta;
       if (rollTimer.current <= 0) isRolling.current = false;
     }
+    pushAvatarSnapshot();
   }
 
   // Returns the new Y position after applying gravity and landing
@@ -110,6 +140,7 @@ export function usePlayerPhysics() {
       }
     }
 
+    pushAvatarSnapshot();
     return newY;
   }
 
@@ -142,12 +173,25 @@ export function usePlayerPhysics() {
     isGrounded,
     isRolling,
     rollTimer,
+    subscribeAvatar,
+    getAvatarSnapshot,
     processJump,
     processRoll,
     tickRoll,
     applyGravity,
     applyMovement,
   };
+}
+
+/**
+ * Subscribe to physics flags that affect React-rendered UI (avatar pose, etc.).
+ * Physics uses refs for the sim; this bridges ref updates to re-renders without ad-hoc useState per flag.
+ */
+export function usePlayerPhysicsAvatarSync(physics: {
+  subscribeAvatar: (onStoreChange: () => void) => () => void;
+  getAvatarSnapshot: () => PlayerPhysicsAvatarSnapshot;
+}) {
+  return useSyncExternalStore(physics.subscribeAvatar, physics.getAvatarSnapshot);
 }
 
 function hasCollision(position: [number, number, number], otherPlayers: Record<string, Player>, extraBoxes: THREE.Box3[] = []): boolean {

--- a/src/utils/overlayTextSync.ts
+++ b/src/utils/overlayTextSync.ts
@@ -1,0 +1,19 @@
+﻿import * as THREE from 'three';
+
+const OVERLAY_TEXT_RENDER_ORDER = 1000;
+
+/**
+ * Use as drei <Text onSync={onOverlayTextSync} /> so floating prompts
+ * are not occluded by walls (depth test off, high render order).
+ */
+export function onOverlayTextSync(troika: THREE.Object3D) {
+  troika.renderOrder = OVERLAY_TEXT_RENDER_ORDER;
+  const mesh = troika as THREE.Mesh;
+  const mats = mesh.material;
+  const apply = (m: THREE.Material) => {
+    m.depthTest = false;
+    m.depthWrite = false;
+  };
+  if (Array.isArray(mats)) mats.forEach(apply);
+  else if (mats) apply(mats);
+}


### PR DESCRIPTION
World: add overlayTextSync (renderOrder, depthTest off) for Billboard Text on desk, whiteboard, water cooler, and throwable props so interaction prompts stay visible when viewed past walls.

Player: expose grounded/rolling via useSyncExternalStore (usePlayerPhysicsAvatarSync) so CharacterAvatar re-renders when landing or roll state changes; refs alone do not trigger updates.

Fixes #17

Fixes #19

Made-with: Cursor