### PR TITLE
Fix #24 and #25: sync focus sit pose for remote avatars

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -876,7 +876,12 @@ io.on("connection", (socket) => {
       }
     });
 
-    socket.on("playerFocusUpdate", (data: { isFocused: boolean; focusProgress: number; activeDeskId: string | null }) => {
+    socket.on("playerFocusUpdate", (data: {
+      isFocused: boolean;
+      focusProgress: number;
+      activeDeskId: string | null;
+      focusSitPoseIndex?: number;
+    }) => {
       let playerRoom = "";
       for (const roomId in rooms) {
         if (rooms[roomId][socket.id]) {
@@ -889,6 +894,11 @@ io.on("connection", (socket) => {
         rooms[playerRoom][socket.id].isFocused = data.isFocused;
         rooms[playerRoom][socket.id].focusProgress = data.focusProgress;
         rooms[playerRoom][socket.id].activeDeskId = data.activeDeskId;
+        if (data.isFocused && typeof data.focusSitPoseIndex === "number") {
+          rooms[playerRoom][socket.id].focusSitPoseIndex = data.focusSitPoseIndex;
+        } else {
+          delete rooms[playerRoom][socket.id].focusSitPoseIndex;
+        }
         socket.to(playerRoom).emit("playerMoved", rooms[playerRoom][socket.id]);
       }
     });

--- a/src/avatarFocusPoses.ts
+++ b/src/avatarFocusPoses.ts
@@ -1,0 +1,22 @@
+/**
+ * Seated leg presets for desk focus: hip Euler rotations [lx, ly, lz, rx, ry, rz] (radians).
+ * Single-segment legs: large lx ≈ thighs forward; ly opens legs sideways for “劈叉” reads.
+ */
+export const FOCUS_SIT_POSES: ReadonlyArray<readonly [number, number, number, number, number, number]> = [
+  // 0 — 向前平伸：两腿尽量同向朝前伸出（高 lx，几乎无侧摆）
+  [1.52, 0.02, 0.06, 1.52, -0.02, -0.06],
+
+  // 1 — 单腿前抬：左腿高抬前伸，右腿收回下垂（像一条腿架起来）
+  [1.58, 0.12, 0.1, 0.18, -0.06, -0.12],
+
+  // 2 — 横向劈叉（中开）：髋外展，两腿向左右打开仍保持坐姿前倾
+  [0.98, -0.58, 0.2, 0.98, 0.58, -0.2],
+
+  // 3 — 横向劈叉（大开）：劈得更开，和 2 明显不同
+  [0.88, -0.72, 0.26, 0.88, 0.72, -0.26],
+
+  // 4 — 混合：一腿向前平伸，另一腿向侧方打开
+  [1.45, -0.08, 0.14, 0.95, 0.48, -0.22],
+];
+
+export const FOCUS_SIT_POSE_COUNT = FOCUS_SIT_POSES.length;

--- a/src/components/player/CharacterAvatar.tsx
+++ b/src/components/player/CharacterAvatar.tsx
@@ -3,7 +3,13 @@ import { useFrame } from '@react-three/fiber';
 import { Box } from '@react-three/drei';
 import * as THREE from 'three';
 import { MS_BODY_THROWABLE_ID } from '../../propIds';
+import { FOCUS_SIT_POSES, FOCUS_SIT_POSE_COUNT } from '../../avatarFocusPoses';
 import { WornMsBody } from './WornMsBody';
+
+export { FOCUS_SIT_POSES, FOCUS_SIT_POSE_COUNT } from '../../avatarFocusPoses';
+
+/** Local +Z = toward desk when seated; shifts thighs forward past the chair seat. */
+const FOCUS_LEG_FORWARD_Z = 0.14;
 
 export const CharacterAvatar = ({
   color,
@@ -14,6 +20,8 @@ export const CharacterAvatar = ({
   skinTone = '#ffdbac',
   pantColor = '#333333',
   wornUpperPropId,
+  isFocused = false,
+  focusSitPoseIndex = 0,
 }: {
   color: string;
   isMoving: boolean;
@@ -23,6 +31,10 @@ export const CharacterAvatar = ({
   skinTone?: string;
   pantColor?: string;
   wornUpperPropId?: string | null;
+  /** When true, legs use a seated preset instead of standing idle. */
+  isFocused?: boolean;
+  /** Index into `FOCUS_SIT_POSES` (clamped). */
+  focusSitPoseIndex?: number;
 }) => {
   const groupRef = useRef<THREE.Group>(null);
   const leftArmRef = useRef<THREE.Mesh>(null);
@@ -44,29 +56,107 @@ export const CharacterAvatar = ({
       return;
     }
 
+    if (isFocused) {
+      const idx = Math.min(
+        Math.max(0, focusSitPoseIndex),
+        FOCUS_SIT_POSE_COUNT - 1
+      );
+      const [lx, ly, lz, rx, ry, rz] = FOCUS_SIT_POSES[idx]!;
+      if (leftArmRef.current) {
+        leftArmRef.current.rotation.x = 0.38;
+        leftArmRef.current.rotation.y = -0.06;
+        leftArmRef.current.rotation.z = 0.05;
+      }
+      if (rightArmRef.current) {
+        rightArmRef.current.rotation.x = 0.38;
+        rightArmRef.current.rotation.y = 0.06;
+        rightArmRef.current.rotation.z = -0.05;
+      }
+      if (leftLegRef.current) {
+        leftLegRef.current.rotation.x = lx;
+        leftLegRef.current.rotation.y = ly;
+        leftLegRef.current.rotation.z = lz;
+      }
+      if (rightLegRef.current) {
+        rightLegRef.current.rotation.x = rx;
+        rightLegRef.current.rotation.y = ry;
+        rightLegRef.current.rotation.z = rz;
+      }
+      return;
+    }
+
     if (!isGrounded) {
       // Jumping pose
-      if (leftArmRef.current) leftArmRef.current.rotation.x = -Math.PI * 0.2;
-      if (rightArmRef.current) rightArmRef.current.rotation.x = -Math.PI * 0.2;
-      if (leftLegRef.current) leftLegRef.current.rotation.x = Math.PI * 0.1;
-      if (rightLegRef.current) rightLegRef.current.rotation.x = Math.PI * 0.1;
+      if (leftArmRef.current) {
+        leftArmRef.current.rotation.x = -Math.PI * 0.2;
+        leftArmRef.current.rotation.y = 0;
+        leftArmRef.current.rotation.z = 0;
+      }
+      if (rightArmRef.current) {
+        rightArmRef.current.rotation.x = -Math.PI * 0.2;
+        rightArmRef.current.rotation.y = 0;
+        rightArmRef.current.rotation.z = 0;
+      }
+      if (leftLegRef.current) {
+        leftLegRef.current.rotation.x = Math.PI * 0.1;
+        leftLegRef.current.rotation.y = 0;
+        leftLegRef.current.rotation.z = 0;
+      }
+      if (rightLegRef.current) {
+        rightLegRef.current.rotation.x = Math.PI * 0.1;
+        rightLegRef.current.rotation.y = 0;
+        rightLegRef.current.rotation.z = 0;
+      }
     } else if (isMoving) {
       // Walking animation
       const swing = Math.sin(t * walkSpeed) * walkAmount;
-      if (leftArmRef.current) leftArmRef.current.rotation.x = swing;
-      if (rightArmRef.current) rightArmRef.current.rotation.x = -swing;
-      if (leftLegRef.current) leftLegRef.current.rotation.x = -swing;
-      if (rightLegRef.current) rightLegRef.current.rotation.x = swing;
+      if (leftArmRef.current) {
+        leftArmRef.current.rotation.x = swing;
+        leftArmRef.current.rotation.y = 0;
+        leftArmRef.current.rotation.z = 0;
+      }
+      if (rightArmRef.current) {
+        rightArmRef.current.rotation.x = -swing;
+        rightArmRef.current.rotation.y = 0;
+        rightArmRef.current.rotation.z = 0;
+      }
+      if (leftLegRef.current) {
+        leftLegRef.current.rotation.x = -swing;
+        leftLegRef.current.rotation.y = 0;
+        leftLegRef.current.rotation.z = 0;
+      }
+      if (rightLegRef.current) {
+        rightLegRef.current.rotation.x = swing;
+        rightLegRef.current.rotation.y = 0;
+        rightLegRef.current.rotation.z = 0;
+      }
     } else {
       // Idle pose
-      if (leftArmRef.current) leftArmRef.current.rotation.x = 0;
-      if (rightArmRef.current) rightArmRef.current.rotation.x = 0;
-      if (leftLegRef.current) leftLegRef.current.rotation.x = 0;
-      if (rightLegRef.current) rightLegRef.current.rotation.x = 0;
+      if (leftArmRef.current) {
+        leftArmRef.current.rotation.x = 0;
+        leftArmRef.current.rotation.y = 0;
+        leftArmRef.current.rotation.z = 0;
+      }
+      if (rightArmRef.current) {
+        rightArmRef.current.rotation.x = 0;
+        rightArmRef.current.rotation.y = 0;
+        rightArmRef.current.rotation.z = 0;
+      }
+      if (leftLegRef.current) {
+        leftLegRef.current.rotation.x = 0;
+        leftLegRef.current.rotation.y = 0;
+        leftLegRef.current.rotation.z = 0;
+      }
+      if (rightLegRef.current) {
+        rightLegRef.current.rotation.x = 0;
+        rightLegRef.current.rotation.y = 0;
+        rightLegRef.current.rotation.z = 0;
+      }
     }
   });
 
   const suitReplacesHead = wornUpperPropId === MS_BODY_THROWABLE_ID;
+  const legAnchorZ = isFocused ? FOCUS_LEG_FORWARD_Z : 0;
 
   return (
     <group ref={groupRef}>
@@ -104,14 +194,14 @@ export const CharacterAvatar = ({
 
       {suitReplacesHead ? <WornMsBody /> : null}
 
-      {/* Legs */}
-      <group position={[-0.15, 0.5, 0]}>
+      {/* Legs — forward Z when seated so mesh clears chair seat */}
+      <group position={[-0.15, 0.5, legAnchorZ]}>
         <mesh ref={leftLegRef} position={[0, -0.25, 0]}>
           <boxGeometry args={[0.2, 0.5, 0.2]} />
           <meshStandardMaterial color={pantColor} />
         </mesh>
       </group>
-      <group position={[0.15, 0.5, 0]}>
+      <group position={[0.15, 0.5, legAnchorZ]}>
         <mesh ref={rightLegRef} position={[0, -0.25, 0]}>
           <boxGeometry args={[0.2, 0.5, 0.2]} />
           <meshStandardMaterial color={pantColor} />

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -64,6 +64,7 @@ export const LocalPlayer = ({
   const isChatFocused = useGameStore((state) => state.isChatFocused);
   const isInspecting = useGameStore((state) => state.inspectedObject !== null);
   const timeLeft = useGameStore((state) => state.timeLeft);
+  const focusSitPoseIndex = useGameStore((state) => state.focusSitPoseIndex);
   const occupiedDeskIds = useGameStore((state) => state.occupiedDeskIds);
   const roomLayout = useGameStore((state) => state.roomLayout);
   const wornPropId = useGameStore((state) => state.wornPropId);
@@ -99,8 +100,9 @@ export const LocalPlayer = ({
       isFocused: isTimerActive,
       focusProgress,
       activeDeskId: isTimerActive ? activeDeskId : null,
+      focusSitPoseIndex: isTimerActive ? focusSitPoseIndex : undefined,
     });
-  }, [socket, isTimerActive, timeLeft, activeDeskId]);
+  }, [socket, isTimerActive, timeLeft, activeDeskId, focusSitPoseIndex]);
 
   useFrame((state, delta) => {
     // Keep camera below roof
@@ -422,6 +424,8 @@ export const LocalPlayer = ({
             skinTone={avatarConfig?.skinTone ?? DEFAULT_AVATAR_CONFIG.skinTone}
             pantColor={avatarConfig?.pantColor ?? DEFAULT_AVATAR_CONFIG.pantColor}
             wornUpperPropId={wornPropId === MS_BODY_THROWABLE_ID ? MS_BODY_THROWABLE_ID : null}
+            isFocused={isTimerActive}
+            focusSitPoseIndex={focusSitPoseIndex}
           />
         </group>
         <Billboard position={[0, 2.2, 0]}>

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -30,6 +30,8 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
           skinTone={player.avatarConfig?.skinTone ?? DEFAULT_AVATAR_CONFIG.skinTone}
           pantColor={player.avatarConfig?.pantColor ?? DEFAULT_AVATAR_CONFIG.pantColor}
           wornUpperPropId={player.wornPropId === MS_BODY_THROWABLE_ID ? MS_BODY_THROWABLE_ID : null}
+          isFocused={player.isFocused ?? false}
+          focusSitPoseIndex={player.focusSitPoseIndex ?? 0}
         />
       </group>
       <Billboard position={[0, 2.2, 0]}>

--- a/src/components/ui/PomodoroUI.tsx
+++ b/src/components/ui/PomodoroUI.tsx
@@ -17,14 +17,22 @@ export const PomodoroUI = () => {
   } = useGameStore();
 
   useEffect(() => {
-    let interval: NodeJS.Timeout;
-    if (isTimerActive && !isTimerPaused && timeLeft > 0) {
-      interval = setInterval(() => {
-        tickTimer();
-      }, 1000);
-    }
-    return () => clearInterval(interval);
-  }, [isTimerActive, isTimerPaused, timeLeft, tickTimer]);
+    if (!isTimerActive || isTimerPaused) return;
+
+    const sync = () => tickTimer();
+    const id = setInterval(sync, 1000);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') sync();
+    };
+    window.addEventListener('focus', sync);
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      clearInterval(id);
+      window.removeEventListener('focus', sync);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [isTimerActive, isTimerPaused, tickTimer]);
 
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { FOCUS_SIT_POSE_COUNT } from '../avatarFocusPoses';
 import { AvatarConfig, DEFAULT_AVATAR_CONFIG, FurnitureItem, RoomInfo } from '../types';
 
 interface GameState {
@@ -27,8 +28,12 @@ interface GameState {
   isTimerPaused: boolean;
   timerMode: 'focus' | 'break';
   timeLeft: number; // in seconds
+  /** Wall-clock end time for the running timer (null while paused). Keeps countdown accurate when the tab is backgrounded. */
+  timerEndsAt: number | null;
   sessionPaper: number; // paper earned in current focus session
   lastPaperEarnedAt: number; // timestamp — changes when paper is earned, triggers animation
+  /** Random seated leg preset index for the current focus session (set when focus starts). */
+  focusSitPoseIndex: number;
   startTimer: (mode: 'focus' | 'break') => void;
   stopTimer: () => void;
   togglePause: () => void;
@@ -114,48 +119,98 @@ export const useGameStore = create<GameState>((set) => ({
   isTimerPaused: false,
   timerMode: 'focus',
   timeLeft: 25 * 60,
+  timerEndsAt: null,
   sessionPaper: 0,
   lastPaperEarnedAt: 0,
-  startTimer: (mode) => set((state) => ({
-    isTimerActive: true,
-    isTimerPaused: false,
-    timerMode: mode,
-    timeLeft: mode === 'focus' ? 25 * 60 : 5 * 60,
-    activeDeskId: state.nearestDeskId,
-    sessionPaper: 0,
-    lastPaperEarnedAt: 0,
-  })),
-  stopTimer: () => set({ isTimerActive: false, isTimerPaused: false, activeDeskId: null, sessionPaper: 0 }),
-  togglePause: () => set((state) => ({ isTimerPaused: !state.isTimerPaused })),
+  focusSitPoseIndex: 0,
+  startTimer: (mode) =>
+    set((state) => {
+      const durationSec = mode === 'focus' ? 25 * 60 : 5 * 60;
+      const now = Date.now();
+      return {
+        isTimerActive: true,
+        isTimerPaused: false,
+        timerMode: mode,
+        timeLeft: durationSec,
+        timerEndsAt: now + durationSec * 1000,
+        activeDeskId: state.nearestDeskId,
+        sessionPaper: 0,
+        lastPaperEarnedAt: 0,
+        focusSitPoseIndex:
+          mode === 'focus' ? Math.floor(Math.random() * FOCUS_SIT_POSE_COUNT) : state.focusSitPoseIndex,
+      };
+    }),
+  stopTimer: () =>
+    set({
+      isTimerActive: false,
+      isTimerPaused: false,
+      activeDeskId: null,
+      sessionPaper: 0,
+      focusSitPoseIndex: 0,
+      timerEndsAt: null,
+    }),
+  togglePause: () =>
+    set((state) => {
+      if (!state.isTimerActive) return {};
+      const nextPaused = !state.isTimerPaused;
+      if (nextPaused) {
+        return { isTimerPaused: true, timerEndsAt: null };
+      }
+      return {
+        isTimerPaused: false,
+        timerEndsAt: Date.now() + state.timeLeft * 1000,
+      };
+    }),
   tickTimer: () => set((state) => {
     if (state.isTimerPaused || !state.isTimerActive) return {};
 
-    const newTimeLeft = state.timeLeft - 1;
+    const endsAt = state.timerEndsAt ?? Date.now() + state.timeLeft * 1000;
+    const newTimeLeft = Math.max(0, Math.ceil((endsAt - Date.now()) / 1000));
 
     if (newTimeLeft <= 0) {
-      return { isTimerActive: false, isTimerPaused: false, timeLeft: 0, activeDeskId: null };
+      return {
+        isTimerActive: false,
+        isTimerPaused: false,
+        timeLeft: 0,
+        activeDeskId: null,
+        focusSitPoseIndex: 0,
+        timerEndsAt: null,
+      };
     }
 
     let newPaperReams = state.paperReams;
     let newSessionPaper = state.sessionPaper;
     let newLastPaperEarnedAt = state.lastPaperEarnedAt;
 
-    // Passive generation: 1 paper every 30 seconds during focus
-    if (state.timerMode === 'focus' && (1500 - newTimeLeft) % 30 === 0 && newTimeLeft < 1500) {
-      newPaperReams += 1;
-      newSessionPaper += 1;
-      newLastPaperEarnedAt = Date.now();
+    // Passive generation: 1 paper every 30 seconds during focus (derived from wall time so bursts catch up)
+    if (state.timerMode === 'focus') {
+      const targetSessionPaper = Math.floor((1500 - newTimeLeft) / 30);
+      const paperDelta = targetSessionPaper - state.sessionPaper;
+      if (paperDelta > 0) {
+        newPaperReams += paperDelta;
+        newSessionPaper = targetSessionPaper;
+        newLastPaperEarnedAt = Date.now();
+      }
     }
 
-    return { timeLeft: newTimeLeft, paperReams: newPaperReams, sessionPaper: newSessionPaper, lastPaperEarnedAt: newLastPaperEarnedAt };
+    return {
+      timeLeft: newTimeLeft,
+      timerEndsAt: endsAt,
+      paperReams: newPaperReams,
+      sessionPaper: newSessionPaper,
+      lastPaperEarnedAt: newLastPaperEarnedAt,
+    };
   }),
-  resetTimer: () => set((state) => ({
-    isTimerActive: false,
-    isTimerPaused: false,
-    timeLeft: state.timerMode === 'focus' ? 25 * 60 : 5 * 60,
-    activeDeskId: null,
-    sessionPaper: 0,
-  })),
+  resetTimer: () =>
+    set((state) => ({
+      isTimerActive: false,
+      isTimerPaused: false,
+      timeLeft: state.timerMode === 'focus' ? 25 * 60 : 5 * 60,
+      activeDeskId: null,
+      sessionPaper: 0,
+      focusSitPoseIndex: 0,
+      timerEndsAt: null,
+    })),
 
   nearestDeskId: null,
   activeDeskId: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,8 @@ export interface Player {
   rollTimer?: number;
   isFocused?: boolean;
   focusProgress?: number; // 0-1
+  /** Index into seated leg presets; set when focused. */
+  focusSitPoseIndex?: number;
   activeDeskId?: string | null;
   avatarConfig?: AvatarConfig;
   /** Prop id from ThrowableObject (e.g. ms_body) worn on the torso; synced for multiplayer. */


### PR DESCRIPTION
Fixes #24
Fixes #25

- Sync `focusSitPoseIndex` via `playerFocusUpdate` so seated leg presets match for other players.
- Add `FOCUS_SIT_POSES` presets and wire Pomodoro, game store, and CharacterAvatar.

Made with [Cursor](https://cursor.com)