### PR TITLE
feat: display name, job title, desk nameplates, and related updates

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -24,6 +24,10 @@ import {
   CHAIR_UPGRADE_COST_REAMS,
   CHAIR_UPGRADE_MAX_LEVEL,
 } from "./src/chairUpgradeConstants.js";
+import {
+  MONITOR_UPGRADE_MAX_LEVEL,
+  monitorUpgradeCostForNextLevel,
+} from "./src/monitorUpgradeConstants.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -105,6 +109,12 @@ async function initDb() {
   await pool!.query(`
     ALTER TABLE users ADD COLUMN IF NOT EXISTS chair_upgrade_level INTEGER NOT NULL DEFAULT 0
   `);
+  await pool!.query(`
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS monitor_upgrade_level INTEGER NOT NULL DEFAULT 0
+  `);
+  await pool!.query(`
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS job_title TEXT
+  `);
 }
 
 async function getPaperReams(email: string): Promise<number> {
@@ -171,23 +181,40 @@ function extractDeskOwnerEmails(layout: FurnitureItem[]): string[] {
   return [...seen];
 }
 
-async function getChairLevelsForEmails(emails: string[]): Promise<Record<string, number>> {
-  if (emails.length === 0) return {};
-  if (isLocalTest()) return mem.memGetChairLevelsForEmails(emails);
+async function getChairAndMonitorLevelsForEmails(
+  emails: string[]
+): Promise<{ chairs: Record<string, number>; monitors: Record<string, number> }> {
+  if (emails.length === 0) return { chairs: {}, monitors: {} };
+  if (isLocalTest()) {
+    const [chairs, monitors] = await Promise.all([
+      mem.memGetChairLevelsForEmails(emails),
+      mem.memGetMonitorLevelsForEmails(emails),
+    ]);
+    return { chairs, monitors };
+  }
   const { rows } = await pool!.query(
-    "SELECT email, COALESCE(chair_upgrade_level, 0) AS chair_upgrade_level FROM users WHERE email = ANY($1::text[])",
+    "SELECT email, COALESCE(chair_upgrade_level, 0) AS chair_upgrade_level, COALESCE(monitor_upgrade_level, 0) AS monitor_upgrade_level FROM users WHERE email = ANY($1::text[])",
     [emails]
   );
-  const out: Record<string, number> = {};
-  for (const e of emails) out[e] = 0;
+  const chairs: Record<string, number> = {};
+  const monitors: Record<string, number> = {};
+  for (const e of emails) {
+    chairs[e] = 0;
+    monitors[e] = 0;
+  }
   for (const row of rows) {
-    const n = Number(row.chair_upgrade_level);
-    out[row.email] = Math.min(
+    const cn = Number(row.chair_upgrade_level);
+    chairs[row.email] = Math.min(
       CHAIR_UPGRADE_MAX_LEVEL,
-      Math.max(0, Number.isFinite(n) ? Math.floor(n) : 0)
+      Math.max(0, Number.isFinite(cn) ? Math.floor(cn) : 0)
+    );
+    const mn = Number(row.monitor_upgrade_level);
+    monitors[row.email] = Math.min(
+      MONITOR_UPGRADE_MAX_LEVEL,
+      Math.max(0, Number.isFinite(mn) ? Math.floor(mn) : 0)
     );
   }
-  return out;
+  return { chairs, monitors };
 }
 
 type ChairPurchaseResult =
@@ -241,10 +268,63 @@ async function purchaseChairUpgradeTxn(email: string): Promise<ChairPurchaseResu
   }
 }
 
+type MonitorPurchaseResult =
+  | { ok: true; paperReams: number; monitorUpgradeLevel: number }
+  | { ok: false; error: "max_level" | "insufficient" };
+
+async function purchaseMonitorUpgradeTxn(email: string): Promise<MonitorPurchaseResult> {
+  if (isLocalTest()) {
+    return mem.memPurchaseMonitorUpgrade(email);
+  }
+  const client = await pool!.connect();
+  try {
+    await client.query("BEGIN");
+    const sel = await client.query(
+      "SELECT paper_reams, COALESCE(monitor_upgrade_level, 0) AS monitor_upgrade_level FROM users WHERE email = $1 FOR UPDATE",
+      [email]
+    );
+    if (sel.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "insufficient" };
+    }
+    const paper = sel.rows[0].paper_reams as number;
+    let level = Math.floor(Number(sel.rows[0].monitor_upgrade_level));
+    if (!Number.isFinite(level)) level = 0;
+    level = Math.min(MONITOR_UPGRADE_MAX_LEVEL, Math.max(0, level));
+    if (level >= MONITOR_UPGRADE_MAX_LEVEL) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "max_level" };
+    }
+    const cost = monitorUpgradeCostForNextLevel(level);
+    if (paper < cost) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "insufficient" };
+    }
+    const newPaper = paper - cost;
+    const newLevel = level + 1;
+    await client.query(
+      "UPDATE users SET paper_reams = $1, monitor_upgrade_level = $2 WHERE email = $3",
+      [newPaper, newLevel, email]
+    );
+    await client.query("COMMIT");
+    return { ok: true, paperReams: newPaper, monitorUpgradeLevel: newLevel };
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 async function broadcastDeskChairLevels(io: Server, roomId: string, layout: FurnitureItem[]) {
   const emails = extractDeskOwnerEmails(layout);
-  const map = await getChairLevelsForEmails(emails);
-  io.to(roomId).emit("deskChairLevels", map);
+  const { chairs, monitors } = await getChairAndMonitorLevelsForEmails(emails);
+  io.to(roomId).emit("deskChairLevels", chairs);
+  io.to(roomId).emit("deskMonitorLevels", monitors);
 }
 
 async function getRoomLayout(roomId: string): Promise<FurnitureItem[]> {
@@ -351,10 +431,14 @@ async function removeMember(roomId: string, email: string): Promise<void> {
   );
 }
 
-async function getRoomMembers(roomId: string): Promise<Array<{ email: string; name: string | null; role: string; joinedAt: Date }>> {
+async function getRoomMembers(
+  roomId: string
+): Promise<
+  Array<{ email: string; name: string | null; jobTitle: string | null; role: string; joinedAt: Date }>
+> {
   if (isLocalTest()) return mem.memGetRoomMembers(roomId);
   const { rows } = await pool!.query(
-    `SELECT rm.email, u.display_name as name, rm.role, rm.joined_at as "joinedAt"
+    `SELECT rm.email, u.display_name as name, u.job_title as "jobTitle", rm.role, rm.joined_at as "joinedAt"
      FROM room_members rm
      LEFT JOIN users u ON u.email = rm.email
      WHERE rm.room_id = $1
@@ -364,10 +448,14 @@ async function getRoomMembers(roomId: string): Promise<Array<{ email: string; na
   return rows;
 }
 
-async function getRoomLeaderboard(roomId: string): Promise<Array<{ email: string; name: string | null; role: string; paperReams: number }>> {
+async function getRoomLeaderboard(
+  roomId: string
+): Promise<
+  Array<{ email: string; name: string | null; jobTitle: string | null; role: string; paperReams: number }>
+> {
   if (isLocalTest()) return mem.memGetRoomLeaderboard(roomId);
   const { rows } = await pool!.query(
-    `SELECT rm.email, u.display_name as name, rm.role, COALESCE(u.paper_reams, 0) as "paperReams"
+    `SELECT rm.email, u.display_name as name, u.job_title as "jobTitle", rm.role, COALESCE(u.paper_reams, 0) as "paperReams"
      FROM room_members rm
      LEFT JOIN users u ON u.email = rm.email
      WHERE rm.room_id = $1
@@ -416,12 +504,53 @@ async function ensureUserRow(email: string): Promise<void> {
   );
 }
 
-async function upsertUserDisplayName(email: string, displayName: string): Promise<void> {
-  if (isLocalTest()) return mem.memUpsertUserDisplayName(email, displayName);
+/** Seeds display_name from IAP/auth when missing; never overwrites a player-chosen name. */
+async function seedUserDisplayNameFromAuth(email: string, fallbackDisplayName: string): Promise<void> {
+  if (isLocalTest()) return mem.memSeedUserDisplayNameIfEmpty(email, fallbackDisplayName);
   await pool!.query(
     `INSERT INTO users (email, display_name) VALUES ($1, $2)
-     ON CONFLICT (email) DO UPDATE SET display_name = EXCLUDED.display_name`,
-    [email, displayName]
+     ON CONFLICT (email) DO UPDATE SET
+       display_name = COALESCE(users.display_name, EXCLUDED.display_name)`,
+    [email, fallbackDisplayName]
+  );
+}
+
+async function getUserProfileFields(
+  email: string
+): Promise<{ display_name: string | null; job_title: string | null }> {
+  if (isLocalTest()) return mem.memGetUserProfileFields(email);
+  const { rows } = await pool!.query(
+    `SELECT display_name, job_title FROM users WHERE email = $1`,
+    [email]
+  );
+  const r = rows[0];
+  return {
+    display_name: r?.display_name ?? null,
+    job_title: r?.job_title ?? null,
+  };
+}
+
+const MAX_PROFILE_DISPLAY_NAME = 40;
+const MAX_PROFILE_JOB_TITLE = 60;
+
+function sanitizeProfileLine(value: unknown, maxLen: number): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") return null;
+  const t = value.trim().replace(/[\x00-\x1f\x7f]/g, "");
+  if (!t) return null;
+  return t.slice(0, maxLen);
+}
+
+async function saveUserProfileDisplayAndTitle(
+  email: string,
+  displayName: string,
+  jobTitle: string | null
+): Promise<void> {
+  if (isLocalTest()) return mem.memSaveUserProfileFields(email, displayName, jobTitle);
+  await pool!.query(
+    `INSERT INTO users (email, display_name, job_title) VALUES ($1, $2, $3)
+     ON CONFLICT (email) DO UPDATE SET display_name = EXCLUDED.display_name, job_title = EXCLUDED.job_title`,
+    [email, displayName, jobTitle]
   );
 }
 
@@ -511,21 +640,51 @@ async function startServer() {
   app.get("/api/player", async (req, res) => {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
-    const [paperReams, avatarConfig] = await Promise.all([
+    const [paperReams, avatarConfig, profile] = await Promise.all([
       getPaperReams(user.email),
       getAvatarConfig(user.email),
+      getUserProfileFields(user.email),
     ]);
-    res.json({ paperReams, avatarConfig });
+    res.json({
+      paperReams,
+      avatarConfig,
+      displayName: profile.display_name,
+      jobTitle: profile.job_title,
+    });
   });
 
   app.post("/api/avatar", express.json(), async (req, res) => {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
-    const { shirtColor, skinTone, pantColor } = req.body ?? {};
-    if (typeof shirtColor !== 'string' || typeof skinTone !== 'string' || typeof pantColor !== 'string') {
+    const body = req.body ?? {};
+    const { shirtColor, skinTone, pantColor, displayName: rawDisplayName, jobTitle: rawJobTitle } = body;
+    if (typeof shirtColor !== "string" || typeof skinTone !== "string" || typeof pantColor !== "string") {
       return res.status(400).json({ error: "Invalid avatar config" });
     }
     await saveAvatarConfig(user.email, { shirtColor, skinTone, pantColor });
+
+    const hasJobTitleKey = Object.prototype.hasOwnProperty.call(body, "jobTitle");
+    if (rawDisplayName !== undefined || hasJobTitleKey) {
+      const cur = await getUserProfileFields(user.email);
+      let nextName: string;
+      if (rawDisplayName !== undefined) {
+        const s = sanitizeProfileLine(rawDisplayName, MAX_PROFILE_DISPLAY_NAME);
+        if (!s) return res.status(400).json({ error: "Invalid display name" });
+        nextName = s;
+      } else {
+        const fallback = (cur.display_name?.trim() || user.name).slice(0, MAX_PROFILE_DISPLAY_NAME);
+        nextName = fallback || user.email.split("@")[0];
+      }
+      let nextTitle = cur.job_title;
+      if (hasJobTitleKey) {
+        nextTitle =
+          rawJobTitle === null || rawJobTitle === ""
+            ? null
+            : sanitizeProfileLine(rawJobTitle, MAX_PROFILE_JOB_TITLE);
+      }
+      await saveUserProfileDisplayAndTitle(user.email, nextName, nextTitle);
+    }
+
     res.json({ ok: true });
   });
 
@@ -759,8 +918,10 @@ io.on("connection", (socket) => {
         rooms[room] = {};
       }
 
-      // Ensure user row exists and update display name
-      await upsertUserDisplayName(user.email, user.name);
+      await seedUserDisplayNameFromAuth(user.email, user.name);
+      const profileFields = await getUserProfileFields(user.email);
+      const visibleName =
+        (profileFields.display_name && profileFields.display_name.trim()) || user.name;
 
       // Ensure room exists; first joiner (or first joiner with no existing members) becomes admin
       await ensureRoom(room);
@@ -772,8 +933,8 @@ io.on("connection", (socket) => {
       const role = await getMemberRole(room, user.email);
       const isMember = role !== null;
 
-      // Initialize player using authenticated user info
-      const name = user.name;
+      // Initialize player using DB display name when set
+      const name = visibleName;
       rooms[room][socket.id] = {
         id: socket.id,
         email: user.email,
@@ -817,7 +978,7 @@ io.on("connection", (socket) => {
 
       // Desk: only for members (admin/manager/worker)
       if (isMember) {
-        ensurePlayerDesk(room, user.email, user.name)
+        ensurePlayerDesk(room, user.email, visibleName)
           .then(async (layout) => {
             socket.emit("roomLayoutLoaded", layout);
             socket.to(room).emit("roomLayoutUpdated", layout);
@@ -831,8 +992,11 @@ io.on("connection", (socket) => {
         // Visitor: send current layout read-only, no desk created
         getRoomLayout(room).then(async (layout) => {
           socket.emit("roomLayoutLoaded", layout);
-          const map = await getChairLevelsForEmails(extractDeskOwnerEmails(layout));
-          socket.emit("deskChairLevels", map);
+          const { chairs, monitors } = await getChairAndMonitorLevelsForEmails(
+            extractDeskOwnerEmails(layout)
+          );
+          socket.emit("deskChairLevels", chairs);
+          socket.emit("deskMonitorLevels", monitors);
         });
       }
 
@@ -899,6 +1063,45 @@ io.on("connection", (socket) => {
           });
         } catch (e) {
           console.error("purchaseChairUpgrade:", e);
+          respond({ ok: false, error: "server_error" });
+        }
+      }
+    );
+
+    socket.on(
+      "purchaseMonitorUpgrade",
+      async (ack: (r: unknown) => void) => {
+        const respond = typeof ack === "function" ? ack : () => {};
+        let playerRoom = "";
+        for (const roomId in rooms) {
+          if (rooms[roomId][socket.id]) {
+            playerRoom = roomId;
+            break;
+          }
+        }
+        if (!playerRoom) {
+          respond({ ok: false, error: "not_in_room" });
+          return;
+        }
+        try {
+          await ensureUserRow(user.email);
+          const result = await purchaseMonitorUpgradeTxn(user.email);
+          if (!result.ok) {
+            respond(result);
+            return;
+          }
+          socket.emit("paperReamsLoaded", result.paperReams);
+          io.to(playerRoom).emit("monitorLevelUpdated", {
+            email: user.email,
+            level: result.monitorUpgradeLevel,
+          });
+          respond({
+            ok: true,
+            paperReams: result.paperReams,
+            monitorUpgradeLevel: result.monitorUpgradeLevel,
+          });
+        } catch (e) {
+          console.error("purchaseMonitorUpgrade:", e);
           respond({ ok: false, error: "server_error" });
         }
       }

--- a/server/memoryDb.ts
+++ b/server/memoryDb.ts
@@ -1,5 +1,7 @@
 /** In-memory DB for LOCAL_TEST=1 only. Not used when PostgreSQL is active. */
 
+import { MONITOR_UPGRADE_MAX_LEVEL, monitorUpgradeCostForNextLevel } from "../src/monitorUpgradeConstants.js";
+
 /** Starting paper reams for each mock player in local test mode. */
 export const LOCAL_TEST_INITIAL_PAPER_REAMS = 1000;
 
@@ -23,7 +25,9 @@ interface UserRow {
   paper_reams: number;
   avatar_config: Record<string, unknown>;
   display_name: string | null;
+  job_title: string | null;
   chair_upgrade_level: number;
+  monitor_upgrade_level: number;
 }
 
 interface RoomRow {
@@ -57,7 +61,9 @@ function defaultUserRow(): UserRow {
     paper_reams: LOCAL_TEST_INITIAL_PAPER_REAMS,
     avatar_config: {},
     display_name: null,
+    job_title: null,
     chair_upgrade_level: 0,
+    monitor_upgrade_level: 0,
   };
 }
 
@@ -112,13 +118,23 @@ export async function memRemoveMember(roomId: string, email: string): Promise<vo
 
 export async function memGetRoomMembers(
   roomId: string
-): Promise<Array<{ email: string; name: string | null; role: string; joinedAt: Date }>> {
+): Promise<
+  Array<{ email: string; name: string | null; jobTitle: string | null; role: string; joinedAt: Date }>
+> {
   const m = getMemberMap(roomId);
-  const list: Array<{ email: string; name: string | null; role: string; joinedAt: Date }> = [];
+  const list: Array<{
+    email: string;
+    name: string | null;
+    jobTitle: string | null;
+    role: string;
+    joinedAt: Date;
+  }> = [];
   for (const [email, row] of m) {
+    const u = users.get(email);
     list.push({
       email,
-      name: users.get(email)?.display_name ?? null,
+      name: u?.display_name ?? null,
+      jobTitle: u?.job_title ?? null,
       role: row.role,
       joinedAt: row.joined_at,
     });
@@ -129,15 +145,25 @@ export async function memGetRoomMembers(
 
 export async function memGetRoomLeaderboard(
   roomId: string
-): Promise<Array<{ email: string; name: string | null; role: string; paperReams: number }>> {
+): Promise<
+  Array<{ email: string; name: string | null; jobTitle: string | null; role: string; paperReams: number }>
+> {
   const m = getMemberMap(roomId);
-  const list: Array<{ email: string; name: string | null; role: string; paperReams: number }> = [];
+  const list: Array<{
+    email: string;
+    name: string | null;
+    jobTitle: string | null;
+    role: string;
+    paperReams: number;
+  }> = [];
   for (const [email, row] of m) {
+    const u = users.get(email);
     list.push({
       email,
-      name: users.get(email)?.display_name ?? null,
+      name: u?.display_name ?? null,
+      jobTitle: u?.job_title ?? null,
       role: row.role,
-      paperReams: users.get(email)?.paper_reams ?? LOCAL_TEST_INITIAL_PAPER_REAMS,
+      paperReams: u?.paper_reams ?? LOCAL_TEST_INITIAL_PAPER_REAMS,
     });
   }
   list.sort((a, b) => b.paperReams - a.paperReams);
@@ -181,9 +207,33 @@ export async function memEnsureUser(email: string): Promise<void> {
   users.set(email, defaultUserRow());
 }
 
-export async function memUpsertUserDisplayName(email: string, displayName: string): Promise<void> {
+/** Sets display_name from auth only when the user has no display_name yet (matches PG COALESCE seed). */
+export async function memSeedUserDisplayNameIfEmpty(email: string, fallbackDisplayName: string): Promise<void> {
+  const u = users.get(email) ?? defaultUserRow();
+  if (u.display_name == null || u.display_name === "") {
+    u.display_name = fallbackDisplayName;
+  }
+  users.set(email, u);
+}
+
+export async function memGetUserProfileFields(
+  email: string
+): Promise<{ display_name: string | null; job_title: string | null }> {
+  const u = users.get(email);
+  return {
+    display_name: u?.display_name ?? null,
+    job_title: u?.job_title ?? null,
+  };
+}
+
+export async function memSaveUserProfileFields(
+  email: string,
+  displayName: string,
+  jobTitle: string | null
+): Promise<void> {
   const u = users.get(email) ?? defaultUserRow();
   u.display_name = displayName;
+  u.job_title = jobTitle;
   users.set(email, u);
 }
 
@@ -215,6 +265,34 @@ export async function memPurchaseChairUpgrade(
   u.chair_upgrade_level = level + 1;
   users.set(email, u);
   return { ok: true, paperReams: u.paper_reams, chairUpgradeLevel: u.chair_upgrade_level };
+}
+
+const MONITOR_MAX = MONITOR_UPGRADE_MAX_LEVEL;
+
+export async function memGetMonitorLevelsForEmails(emails: string[]): Promise<Record<string, number>> {
+  const out: Record<string, number> = {};
+  for (const e of emails) {
+    const row = users.get(e);
+    const lv = row?.monitor_upgrade_level ?? 0;
+    out[e] = Math.min(MONITOR_MAX, Math.max(0, Math.floor(lv)));
+  }
+  return out;
+}
+
+export type MemMonitorPurchaseResult =
+  | { ok: true; paperReams: number; monitorUpgradeLevel: number }
+  | { ok: false; error: 'max_level' | 'insufficient' };
+
+export async function memPurchaseMonitorUpgrade(email: string): Promise<MemMonitorPurchaseResult> {
+  const u = users.get(email) ?? defaultUserRow();
+  let level = Math.min(MONITOR_MAX, Math.max(0, Math.floor(u.monitor_upgrade_level)));
+  if (level >= MONITOR_MAX) return { ok: false, error: "max_level" };
+  const costReams = monitorUpgradeCostForNextLevel(level);
+  if (u.paper_reams < costReams) return { ok: false, error: "insufficient" };
+  u.paper_reams -= costReams;
+  u.monitor_upgrade_level = level + 1;
+  users.set(email, u);
+  return { ok: true, paperReams: u.paper_reams, monitorUpgradeLevel: u.monitor_upgrade_level };
 }
 
 export async function memUpdateRoomMaxWorkers(roomId: string, maxWorkers: number): Promise<void> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,30 @@ export default function App() {
   const { socket, players, isConnected, chatHistory, lastLocalMessage, disconnectReason, connectionError, sendMessage } =
     useSocket(user, currentRoom);
 
-  const { isTimerActive, paperReams, avatarConfig, setAvatarConfig, setPaperReams, roomLayout, setRoomLayout, roomInfo, showLeaderboard, setShowLeaderboard, showAdminPanel, setShowAdminPanel, showComputerInterface, setShowComputerInterface, showVendingMenu, setShowVendingMenu, setHeldIceCream, setUser } = useGameStore();
+  const {
+    isTimerActive,
+    paperReams,
+    avatarConfig,
+    setAvatarConfig,
+    setPaperReams,
+    roomLayout,
+    setRoomLayout,
+    roomInfo,
+    showLeaderboard,
+    setShowLeaderboard,
+    showAdminPanel,
+    setShowAdminPanel,
+    showComputerInterface,
+    setShowComputerInterface,
+    showVendingMenu,
+    setShowVendingMenu,
+    setHeldIceCream,
+    setUser,
+    playerProfileLoaded,
+    playerProfileDisplayName,
+    playerProfileJobTitle,
+    setPlayerProfileFromServer,
+  } = useGameStore();
   const [view, setView] = useState<'landing' | 'customize' | 'customize-office'>('landing');
 
   useEffect(() => {
@@ -88,17 +111,21 @@ export default function App() {
     }
   }, [user, currentRoom]);
 
-  // Load player stats from DB when on landing page
+  // Load paper, avatar, and profile from DB whenever the authenticated user is known
   useEffect(() => {
-    if (!user || currentRoom) return;
+    if (!user) return;
     fetch('/api/player', { credentials: 'include' })
       .then((r) => r.json())
       .then((data) => {
         if (typeof data.paperReams === 'number') setPaperReams(data.paperReams);
         if (data.avatarConfig) setAvatarConfig(data.avatarConfig);
+        setPlayerProfileFromServer({
+          displayName: data.displayName ?? null,
+          jobTitle: data.jobTitle ?? null,
+        });
       })
       .catch(() => {});
-  }, [user, currentRoom]);
+  }, [user, setPaperReams, setAvatarConfig, setPlayerProfileFromServer]);
 
   const handleSaveOfficeLayout = useCallback(async (layout: FurnitureItem[]) => {
     setRoomLayout(layout);
@@ -110,16 +137,36 @@ export default function App() {
     });
   }, [currentRoom, setRoomLayout]);
 
-  const handleSaveAvatar = useCallback(async (config: typeof avatarConfig) => {
-    setAvatarConfig(config);
-    await fetch('/api/avatar', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify(config),
-    });
-    setView('landing');
-  }, [setAvatarConfig]);
+  const handleSaveAvatar = useCallback(
+    async (payload: {
+      config: typeof avatarConfig;
+      displayName: string;
+      jobTitle: string;
+    }) => {
+      setAvatarConfig(payload.config);
+      setPlayerProfileFromServer({
+        displayName: payload.displayName,
+        jobTitle: payload.jobTitle ? payload.jobTitle : null,
+      });
+      await fetch('/api/avatar', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          ...payload.config,
+          displayName: payload.displayName,
+          jobTitle: payload.jobTitle || null,
+        }),
+      });
+      setView('landing');
+    },
+    [setAvatarConfig, setPlayerProfileFromServer]
+  );
+
+  const visibleDisplayName =
+    playerProfileLoaded && user
+      ? (playerProfileDisplayName?.trim() || user.name)
+      : user?.name ?? '';
 
   // ── Loading ──────────────────────────────────────────────────────────────
   if (authLoading) {
@@ -190,6 +237,8 @@ export default function App() {
     return (
       <AvatarCustomizationPage
         config={avatarConfig}
+        initialDisplayName={visibleDisplayName}
+        initialJobTitle={playerProfileJobTitle ?? ''}
         onSave={handleSaveAvatar}
         onBack={() => setView('landing')}
       />
@@ -210,7 +259,16 @@ export default function App() {
 
   // ── Room selection ───────────────────────────────────────────────────────
   if (!currentRoom) {
-    return <LandingPage onJoin={handleJoin} userName={user.name} onLogout={logout} onCustomize={() => setView('customize')} avatarConfig={avatarConfig} paperReams={paperReams} />;
+    return (
+      <LandingPage
+        onJoin={handleJoin}
+        userName={visibleDisplayName}
+        onLogout={logout}
+        onCustomize={() => setView('customize')}
+        avatarConfig={avatarConfig}
+        paperReams={paperReams}
+      />
+    );
   }
 
   // ── Game ─────────────────────────────────────────────────────────────────
@@ -310,7 +368,7 @@ export default function App() {
               socket={socket}
               lastMessage={lastLocalMessage?.text}
               lastMessageTime={lastLocalMessage?.time}
-              playerName={user.name}
+              playerName={visibleDisplayName}
               players={players}
             />
             {Object.values(players).map((player) => (

--- a/src/components/ui/AvatarCustomizationPage.tsx
+++ b/src/components/ui/AvatarCustomizationPage.tsx
@@ -38,17 +38,29 @@ const PANT_COLORS = [
 
 interface AvatarCustomizationPageProps {
   config: AvatarConfig;
-  onSave: (config: AvatarConfig) => void;
+  initialDisplayName: string;
+  initialJobTitle: string;
+  onSave: (payload: { config: AvatarConfig; displayName: string; jobTitle: string }) => void | Promise<void>;
   onBack: () => void;
 }
 
-export const AvatarCustomizationPage = ({ config, onSave, onBack }: AvatarCustomizationPageProps) => {
+export const AvatarCustomizationPage = ({
+  config,
+  initialDisplayName,
+  initialJobTitle,
+  onSave,
+  onBack,
+}: AvatarCustomizationPageProps) => {
   const [draft, setDraft] = useState<AvatarConfig>(config);
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [jobTitle, setJobTitle] = useState(initialJobTitle);
   const [saving, setSaving] = useState(false);
 
   const handleSave = async () => {
+    const trimmed = displayName.trim();
+    if (!trimmed) return;
     setSaving(true);
-    await onSave(draft);
+    await onSave({ config: draft, displayName: trimmed, jobTitle: jobTitle.trim() });
     setSaving(false);
   };
 
@@ -89,6 +101,28 @@ export const AvatarCustomizationPage = ({ config, onSave, onBack }: AvatarCustom
 
           {/* Options */}
           <div className="flex-1 space-y-6">
+            <Section label="DISPLAY NAME">
+              <input
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                maxLength={40}
+                className="w-full px-2 py-1.5 text-[10px] font-pixel border-2 border-slate-400 bg-white text-black outline-none focus:border-indigo-600"
+                placeholder="Name shown in-game"
+                autoComplete="nickname"
+              />
+            </Section>
+            <Section label="TITLE (OPTIONAL)">
+              <input
+                type="text"
+                value={jobTitle}
+                onChange={(e) => setJobTitle(e.target.value)}
+                maxLength={60}
+                className="w-full px-2 py-1.5 text-[10px] font-pixel border-2 border-slate-400 bg-white text-black outline-none focus:border-indigo-600"
+                placeholder="e.g. Assistant to the Regional Manager"
+                autoComplete="organization-title"
+              />
+            </Section>
             <Section label="SHIRT COLOR">
               <SwatchGrid
                 options={SHIRT_COLORS}
@@ -118,7 +152,7 @@ export const AvatarCustomizationPage = ({ config, onSave, onBack }: AvatarCustom
         <div className="flex flex-col gap-3 mt-8">
           <button
             onClick={handleSave}
-            disabled={saving}
+            disabled={saving || !displayName.trim()}
             className="pixel-button text-xs py-4 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {saving ? 'SAVING...' : 'SAVE APPEARANCE'}

--- a/src/components/ui/PomodoroUI.tsx
+++ b/src/components/ui/PomodoroUI.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { Timer, Coffee, Play, Square, Pause } from 'lucide-react';
+import { focusReamsPerMinute } from '../../monitorUpgradeConstants';
 import { useGameStore } from '../../store/useGameStore';
 
 export const PomodoroUI = () => {
@@ -14,7 +15,13 @@ export const PomodoroUI = () => {
     togglePause,
     nearestDeskId,
     sessionPaper,
+    user,
+    monitorLevelByEmail,
   } = useGameStore();
+  const focusEarnPerMin =
+    user?.email !== undefined
+      ? focusReamsPerMinute(monitorLevelByEmail[user.email] ?? 0)
+      : focusReamsPerMinute(0);
 
   useEffect(() => {
     if (!isTimerActive || isTimerPaused) return;
@@ -71,6 +78,13 @@ export const PomodoroUI = () => {
               <div className="flex flex-col items-center gap-1 mb-6">
                 <div className="text-indigo-300 text-[10px] uppercase tracking-[0.2em] font-bold animate-pulse text-center">
                   {isTimerPaused ? 'Session Paused' : 'Stay Focused on your real tasks...'}
+                </div>
+                <div className="text-slate-400 font-mono text-[10px]">
+                  Earn rate:{' '}
+                  <span className="text-cyan-300/90">
+                    {focusEarnPerMin} reams/min
+                  </span>
+                  {isTimerPaused ? ' (paused)' : ''}
                 </div>
                 {sessionPaper > 0 && (
                   <div className="flex items-center gap-1.5 bg-emerald-500/20 border border-emerald-500/40 px-3 py-1 rounded-full">

--- a/src/components/ui/RoomAdminPanel.tsx
+++ b/src/components/ui/RoomAdminPanel.tsx
@@ -160,6 +160,9 @@ export const RoomAdminPanel = ({ roomId, onClose }: RoomAdminPanelProps) => {
                 <div key={m.email} className="flex items-center gap-2 bg-white pixel-border px-3 py-2">
                   <div className="flex-1 min-w-0">
                     <div className="text-[10px] font-bold truncate">{displayName(m.email, m.name)}</div>
+                    {m.jobTitle ? (
+                      <div className="text-[8px] text-slate-500 truncate">{m.jobTitle}</div>
+                    ) : null}
                     <div className="flex items-center gap-1.5 mt-0.5">
                       <RoleBadge role={m.role} />
                       {m.isOnline

--- a/src/components/ui/RoomLeaderboard.tsx
+++ b/src/components/ui/RoomLeaderboard.tsx
@@ -6,6 +6,7 @@ import { RoomRole } from '../../types';
 interface LeaderboardEntry {
   email: string;
   name: string | null;
+  jobTitle?: string | null;
   role: RoomRole;
   paperReams: number;
 }
@@ -54,7 +55,7 @@ export const RoomLeaderboard = ({ roomId, onClose }: RoomLeaderboardProps) => {
     return () => clearInterval(interval);
   }, [roomId]);
 
-  const displayName = (entry: LeaderboardEntry) =>
+  const primaryName = (entry: LeaderboardEntry) =>
     entry.name ?? entry.email.split('@')[0];
 
   return (
@@ -97,12 +98,15 @@ export const RoomLeaderboard = ({ roomId, onClose }: RoomLeaderboardProps) => {
                   }`}>
                     {i + 1}
                   </span>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-1.5">
+                  <div className="flex-1 min-w-0 flex flex-col gap-1">
+                    <div className="flex flex-col gap-0.5 min-w-0">
                       <span className={`text-xs font-semibold truncate ${isMe ? 'text-indigo-200' : 'text-white'}`}>
-                        {displayName(entry)}
+                        {primaryName(entry)}
                         {isMe && <span className="text-indigo-400 ml-1">(you)</span>}
                       </span>
+                      {entry.jobTitle ? (
+                        <span className="text-[9px] text-slate-400 truncate leading-tight">{entry.jobTitle}</span>
+                      ) : null}
                     </div>
                     <RoleBadge role={entry.role} />
                   </div>

--- a/src/components/ui/VendingMenu.tsx
+++ b/src/components/ui/VendingMenu.tsx
@@ -7,6 +7,10 @@ import {
   CHAIR_UPGRADE_COST_REAMS,
   CHAIR_UPGRADE_MAX_LEVEL,
 } from '../../chairUpgradeConstants';
+import {
+  MONITOR_UPGRADE_MAX_LEVEL,
+  monitorUpgradeCostForNextLevel,
+} from '../../monitorUpgradeConstants';
 
 /** Ice cream price in paper reams (syncs to server via existing savePaperReams). */
 const ICE_CREAM_COST_REAMS = 2;
@@ -21,6 +25,10 @@ type ChairPurchaseAck =
   | { ok: true; paperReams: number; chairUpgradeLevel: number }
   | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
 
+type MonitorPurchaseAck =
+  | { ok: true; paperReams: number; monitorUpgradeLevel: number }
+  | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
+
 export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const paperReams = useGameStore((s) => s.paperReams);
   const addPaper = useGameStore((s) => s.addPaper);
@@ -29,11 +37,17 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const chairLevelByEmail = useGameStore((s) => s.chairLevelByEmail);
   const setPaperReams = useGameStore((s) => s.setPaperReams);
   const patchChairLevel = useGameStore((s) => s.patchChairLevel);
+  const monitorLevelByEmail = useGameStore((s) => s.monitorLevelByEmail);
+  const patchMonitorLevel = useGameStore((s) => s.patchMonitorLevel);
   const [subView, setSubView] = useState<'main' | 'flavor'>('main');
   const [selectedFlavor, setSelectedFlavor] = useState(0);
   const [feedback, setFeedback] = useState<'insufficient' | 'offline' | null>(null);
   const [chairBusy, setChairBusy] = useState(false);
   const [chairFeedback, setChairFeedback] = useState<
+    'insufficient' | 'max_level' | 'offline' | 'not_in_room' | 'server_error' | null
+  >(null);
+  const [monitorBusy, setMonitorBusy] = useState(false);
+  const [monitorFeedback, setMonitorFeedback] = useState<
     'insufficient' | 'max_level' | 'offline' | 'not_in_room' | 'server_error' | null
   >(null);
 
@@ -58,6 +72,11 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const myChairLevel = user?.email ? (chairLevelByEmail[user.email] ?? 0) : 0;
   const chairMaxed = myChairLevel >= CHAIR_UPGRADE_MAX_LEVEL;
   const canAffordChair = paperReams >= CHAIR_UPGRADE_COST_REAMS;
+
+  const myMonitorLevel = user?.email ? (monitorLevelByEmail[user.email] ?? 0) : 0;
+  const monitorMaxed = myMonitorLevel >= MONITOR_UPGRADE_MAX_LEVEL;
+  const nextMonitorCost = monitorMaxed ? 0 : monitorUpgradeCostForNextLevel(myMonitorLevel);
+  const canAffordMonitor = !monitorMaxed && paperReams >= nextMonitorCost;
 
   const openFlavorSubmenu = () => {
     setFeedback(null);
@@ -117,6 +136,45 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
       else if (fail === 'insufficient') setChairFeedback('insufficient');
       else if (fail === 'not_in_room') setChairFeedback('not_in_room');
       else setChairFeedback('server_error');
+    });
+  };
+
+  const handleBuyMonitorUpgrade = () => {
+    setMonitorFeedback(null);
+    if (!socket?.connected) {
+      setMonitorFeedback('offline');
+      return;
+    }
+    if (monitorMaxed) {
+      setMonitorFeedback('max_level');
+      return;
+    }
+    if (!canAffordMonitor) {
+      setMonitorFeedback('insufficient');
+      return;
+    }
+    setMonitorBusy(true);
+    socket.timeout(12_000).emit('purchaseMonitorUpgrade', (socketErr: Error | null, res: unknown) => {
+      setMonitorBusy(false);
+      if (socketErr) {
+        setMonitorFeedback('server_error');
+        return;
+      }
+      const r = res as MonitorPurchaseAck;
+      if (!r || typeof r !== 'object' || !('ok' in r)) {
+        setMonitorFeedback('server_error');
+        return;
+      }
+      if (r.ok === true) {
+        setPaperReams(r.paperReams);
+        if (user?.email) patchMonitorLevel(user.email, r.monitorUpgradeLevel);
+        return;
+      }
+      const fail = r.error;
+      if (fail === 'max_level') setMonitorFeedback('max_level');
+      else if (fail === 'insufficient') setMonitorFeedback('insufficient');
+      else if (fail === 'not_in_room') setMonitorFeedback('not_in_room');
+      else setMonitorFeedback('server_error');
     });
   };
 
@@ -234,6 +292,73 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
               </p>
             )}
             {chairFeedback === 'offline' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mt-2">
+                Not connected — try again when online.
+              </p>
+            )}
+
+            <div className="border-2 border-cyan-700/40 bg-cyan-950/20 p-4 mb-4 mt-6">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-pixel text-[8px] sm:text-[10px] text-cyan-100 mb-1">
+                    Desk monitors
+                  </p>
+                  <p className="text-slate-400 text-[10px] sm:text-xs font-mono leading-snug">
+                    Add a screen on your desk each time (up to 8). First 3 upgrades also add +1 ream/min
+                    while focusing; later ones are look-only.
+                  </p>
+                  <p className="text-slate-500 font-mono text-[9px] mt-2">
+                    Upgrades:{' '}
+                    <span className="text-cyan-200">
+                      {myMonitorLevel}/{MONITOR_UPGRADE_MAX_LEVEL}
+                    </span>
+                    {!monitorMaxed && (
+                      <span className="text-slate-500">
+                        {' '}
+                        → next: {1 + myMonitorLevel} monitors ({nextMonitorCost} reams)
+                      </span>
+                    )}
+                  </p>
+                </div>
+                {!monitorMaxed && (
+                  <span className="font-mono text-cyan-300 text-sm shrink-0">{nextMonitorCost} reams</span>
+                )}
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleBuyMonitorUpgrade}
+              disabled={!socketOk || monitorMaxed || monitorBusy}
+              className="pixel-button font-pixel text-[8px] sm:text-[10px] text-center w-full disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {monitorMaxed
+                ? 'Monitors maxed (8 screens)'
+                : monitorBusy
+                  ? 'Processing…'
+                  : `Add monitor (${nextMonitorCost} reams)`}
+            </button>
+            {monitorFeedback === 'insufficient' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mt-2">
+                Not enough reams.
+              </p>
+            )}
+            {monitorFeedback === 'max_level' && (
+              <p className="text-center text-slate-400 text-xs font-mono mt-2">
+                Already at max ({MONITOR_UPGRADE_MAX_LEVEL} upgrades, 8 monitors).
+              </p>
+            )}
+            {monitorFeedback === 'not_in_room' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mt-2">
+                Join the office room first.
+              </p>
+            )}
+            {monitorFeedback === 'server_error' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mt-2">
+                Could not complete purchase — try again.
+              </p>
+            )}
+            {monitorFeedback === 'offline' && (
               <p className="text-center text-rose-400/90 text-xs font-mono mt-2">
                 Not connected — try again when online.
               </p>

--- a/src/components/world/conference-room/props/Whiteboard.tsx
+++ b/src/components/world/conference-room/props/Whiteboard.tsx
@@ -12,6 +12,7 @@ interface WhiteboardProps {
 
 interface TopEntry {
   name: string | null;
+  jobTitle?: string | null;
   email: string;
   paperReams: number;
 }
@@ -59,6 +60,7 @@ export const Whiteboard = ({ position, rotation = [0, 0, 0] }: WhiteboardProps) 
   const displayName = topEntry
     ? (topEntry.name ?? topEntry.email.split('@')[0])
     : null;
+  const titleLine = topEntry?.jobTitle?.trim() || null;
 
   return (
     <group ref={groupRef} position={position} rotation={rotation}>
@@ -97,10 +99,15 @@ export const Whiteboard = ({ position, rotation = [0, 0, 0] }: WhiteboardProps) 
           <Text position={[-2.0, 0.45, 0.04]} fontSize={0.34} color="#c8a000" anchorX="center" anchorY="middle">
             #1
           </Text>
-          <Text position={[0.5, 0.45, 0.04]} fontSize={0.28} color="#1a1a1a" anchorX="center" anchorY="middle">
+          <Text position={[0.5, titleLine ? 0.55 : 0.45, 0.04]} fontSize={0.28} color="#1a1a1a" anchorX="center" anchorY="middle">
             {displayName}
           </Text>
-          <Text position={[0.5, 0.05, 0.04]} fontSize={0.22} color="#555" anchorX="center" anchorY="middle">
+          {titleLine ? (
+            <Text position={[0.5, 0.28, 0.04]} fontSize={0.16} color="#555" anchorX="center" anchorY="middle">
+              {titleLine}
+            </Text>
+          ) : null}
+          <Text position={[0.5, titleLine ? -0.02 : 0.05, 0.04]} fontSize={0.22} color="#555" anchorX="center" anchorY="middle">
             {`${topEntry!.paperReams.toLocaleString()} reams`}
           </Text>
         </>

--- a/src/components/world/working-area/Desk.tsx
+++ b/src/components/world/working-area/Desk.tsx
@@ -1,10 +1,57 @@
-import React, { useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import { Box, Billboard, Text, Cylinder } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { MONITOR_UPGRADE_MAX_LEVEL } from '../../../monitorUpgradeConstants';
 import { useGameStore } from '../../../store/useGameStore';
 import { Chair } from '../shared/props/Chair';
 import { onOverlayTextSync } from '../../../utils/overlayTextSync';
+
+function SingleDeskMonitor() {
+  return (
+    <group>
+      <Box args={[0.65, 0.42, 0.05]} position={[0, 0.21, -0.2]}>
+        <meshStandardMaterial color="#111111" />
+      </Box>
+      <Box args={[0.55, 0.32, 0.01]} position={[0, 0.21, -0.17]}>
+        <meshStandardMaterial color="#0a1f33" emissive="#1a3a5c" emissiveIntensity={0.6} />
+      </Box>
+      <Box args={[0.2, 0.05, 0.2]} position={[0, 0.025, -0.2]}>
+        <meshStandardMaterial color="#222" />
+      </Box>
+      <Box args={[0.4, 0.02, 0.2]} position={[0, 0.01, 0.1]}>
+        <meshStandardMaterial color="#222" />
+      </Box>
+    </group>
+  );
+}
+
+function DeskMonitors({ count }: { count: number }) {
+  const c = Math.min(8, Math.max(1, Math.floor(count)));
+  const maxRowW = 1.72;
+  const unitW = 0.65;
+  const gap = 0.06;
+  const denom = c * unitW + Math.max(0, c - 1) * gap;
+  /** Use desk width when few monitors; cap so one screen does not dominate the desk. */
+  const fitScale = maxRowW / denom;
+  const maxScaleForFew = 1.28;
+  const scale = Math.min(fitScale, maxScaleForFew);
+  const step = scale * (unitW + gap);
+  const mid = (c - 1) / 2;
+  return (
+    <group position={[0, 1.0, 0]}>
+      {Array.from({ length: c }, (_, i) => (
+        <group
+          key={i}
+          position={[(i - mid) * step, 0, 0]}
+          scale={[scale, scale, scale]}
+        >
+          <SingleDeskMonitor />
+        </group>
+      ))}
+    </group>
+  );
+}
 
 export const Desk = ({
   id,
@@ -31,6 +78,26 @@ export const Desk = ({
   const myRole = useGameStore((state) => state.roomInfo?.myRole);
   const chairLevelByEmail = useGameStore((state) => state.chairLevelByEmail);
   const chairLevel = ownerEmail ? (chairLevelByEmail[ownerEmail] ?? 0) : 0;
+  const monitorLevelByEmail = useGameStore((state) => state.monitorLevelByEmail);
+  const rawMonitorLv = ownerEmail ? (monitorLevelByEmail[ownerEmail] ?? 0) : 0;
+  const monitorLv = Math.min(
+    MONITOR_UPGRADE_MAX_LEVEL,
+    Math.max(0, Math.floor(rawMonitorLv))
+  );
+  const monitorCount = 1 + monitorLv;
+
+  const members = useGameStore((state) => state.roomInfo?.members);
+  const resolvedDeskOwnerName = useMemo(() => {
+    const layoutName = ownerName?.trim();
+    if (!ownerEmail) return layoutName || '';
+    const m = members?.find((x) => x.email === ownerEmail);
+    const fromDb = m?.name?.trim();
+    if (fromDb) return fromDb;
+    if (layoutName) return layoutName;
+    return ownerEmail.split('@')[0] ?? '';
+  }, [members, ownerEmail, ownerName]);
+
+  const deskNameplate = resolvedDeskOwnerName ? `${resolvedDeskOwnerName}'s desk` : '';
 
   const isOwnDesk = !!ownerEmail && ownerEmail === userEmail;
   const isOwnAdminDesk = isOwnDesk && (myRole === 'admin' || myRole === 'manager');
@@ -52,7 +119,7 @@ export const Desk = ({
 
   return (
     <group ref={deskRef} position={position} rotation={rotation}>
-      {ownerName && (
+      {deskNameplate && (
         <Billboard position={[0, 1.8, 0]}>
           <Text
             fontSize={0.18}
@@ -61,7 +128,7 @@ export const Desk = ({
             outlineWidth={0.02}
             onSync={onOverlayTextSync}
           >
-            {ownerName}
+            {deskNameplate}
           </Text>
         </Billboard>
       )}
@@ -128,29 +195,7 @@ export const Desk = ({
         <meshStandardMaterial color="#1a1a1a" />
       </Box>
 
-      {/* Monitor — improved with larger bezel and glowing screen */}
-      <group position={[0, 1.0, 0]}>
-        {/* Bezel */}
-        <Box args={[0.65, 0.42, 0.05]} position={[0, 0.21, -0.2]}>
-          <meshStandardMaterial color="#111111" />
-        </Box>
-        {/* Inner screen with blue emissive glow */}
-        <Box args={[0.55, 0.32, 0.01]} position={[0, 0.21, -0.17]}>
-          <meshStandardMaterial
-            color="#0a1f33"
-            emissive="#1a3a5c"
-            emissiveIntensity={0.6}
-          />
-        </Box>
-        {/* Monitor stand neck */}
-        <Box args={[0.2, 0.05, 0.2]} position={[0, 0.025, -0.2]}>
-          <meshStandardMaterial color="#222" />
-        </Box>
-        {/* Monitor stand base */}
-        <Box args={[0.4, 0.02, 0.2]} position={[0, 0.01, 0.1]}>
-          <meshStandardMaterial color="#222" />
-        </Box>
-      </group>
+      <DeskMonitors count={monitorCount} />
 
       {hasChair && (
         <Chair position={[0, 0, 0.8]} rotation={[0, Math.PI, 0]} level={chairLevel} />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,12 @@
 import * as THREE from 'three';
 
 export { CHAIR_UPGRADE_COST_REAMS, CHAIR_UPGRADE_MAX_LEVEL } from './chairUpgradeConstants';
+export {
+  MONITOR_UPGRADE_MAX_LEVEL,
+  FOCUS_BASE_REAMS_PER_MINUTE,
+  monitorUpgradeCostForNextLevel,
+  focusReamsPerMinute,
+} from './monitorUpgradeConstants';
 import { WORKING_AREA_COLLISION_BOXES } from './components/world/working-area/WorkingArea';
 import { BREAK_ROOM_COLLISION_BOXES } from './components/world/break-room/BreakRoom';
 import { CONFERENCE_ROOM_COLLISION_BOXES } from './components/world/conference-room/ConferenceRoom';

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -201,9 +201,19 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       if (map && typeof map === 'object') useGameStore.getState().setDeskChairLevels(map);
     });
 
+    newSocket.on('deskMonitorLevels', (map: Record<string, number>) => {
+      if (map && typeof map === 'object') useGameStore.getState().setDeskMonitorLevels(map);
+    });
+
     newSocket.on('chairLevelUpdated', (payload: { email: string; level: number }) => {
       if (payload?.email && typeof payload.level === 'number') {
         useGameStore.getState().patchChairLevel(payload.email, payload.level);
+      }
+    });
+
+    newSocket.on('monitorLevelUpdated', (payload: { email: string; level: number }) => {
+      if (payload?.email && typeof payload.level === 'number') {
+        useGameStore.getState().patchMonitorLevel(payload.email, payload.level);
       }
     });
 
@@ -243,6 +253,7 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       console.log(`[socket] cleaning up, disconnecting from room=${currentRoom}`);
       unsubscribeReams();
       useGameStore.getState().resetChairLevels();
+      useGameStore.getState().resetMonitorLevels();
       useGameStore.getState().setRoomInfo(null);
       useGameStore.getState().setRemoteWornThrowableIds([]);
       useGameStore.getState().clearWornProp();

--- a/src/monitorUpgradeConstants.ts
+++ b/src/monitorUpgradeConstants.ts
@@ -1,0 +1,21 @@
+/** Shared server + client: vending machine desk monitor upgrades. */
+
+/** Purchases made (0–7); monitor count = 1 + level (max 8 monitors). */
+export const MONITOR_UPGRADE_MAX_LEVEL = 7;
+
+/** Reams earned per minute during focus at monitor upgrade level 0 (baseline). */
+export const FOCUS_BASE_REAMS_PER_MINUTE = 2;
+
+export function monitorUpgradeCostForNextLevel(currentLevel: number): number {
+  const L = Math.min(MONITOR_UPGRADE_MAX_LEVEL, Math.max(0, Math.floor(currentLevel)));
+  const next = L + 1;
+  if (next === 1) return 200;
+  if (next === 2) return 300;
+  return 500;
+}
+
+/** First three upgrades each add +1 ream/min while focusing; further upgrades are cosmetic only. */
+export function focusReamsPerMinute(monitorUpgradeLevel: number): number {
+  const lv = Math.min(MONITOR_UPGRADE_MAX_LEVEL, Math.max(0, Math.floor(monitorUpgradeLevel)));
+  return FOCUS_BASE_REAMS_PER_MINUTE + Math.min(lv, 3);
+}

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { FOCUS_SIT_POSE_COUNT } from '../avatarFocusPoses';
+import { MONITOR_UPGRADE_MAX_LEVEL, focusReamsPerMinute } from '../monitorUpgradeConstants';
 import { AvatarConfig, DEFAULT_AVATAR_CONFIG, FurnitureItem, RoomInfo } from '../types';
 
 interface GameState {
@@ -47,11 +48,19 @@ interface GameState {
   occupiedDeskIds: string[];
   user: { email: string; name: string; picture?: string } | null;
   avatarConfig: AvatarConfig;
+  /** After `/api/player`; null displayName means use auth `user.name` in UI. */
+  playerProfileLoaded: boolean;
+  playerProfileDisplayName: string | null;
+  playerProfileJobTitle: string | null;
   setNearestDeskId: (id: string | null) => void;
   setChatFocused: (focused: boolean) => void;
   setOccupiedDeskIds: (ids: string[]) => void;
   setUser: (user: { email: string; name: string; picture?: string } | null) => void;
   setAvatarConfig: (config: AvatarConfig) => void;
+  setPlayerProfileFromServer: (profile: {
+    displayName: string | null;
+    jobTitle: string | null;
+  }) => void;
   roomLayout: FurnitureItem[];
   setRoomLayout: (layout: FurnitureItem[]) => void;
   /** Desk owner email → vending chair upgrade level (0–20); synced from server. */
@@ -59,6 +68,11 @@ interface GameState {
   setDeskChairLevels: (map: Record<string, number>) => void;
   patchChairLevel: (email: string, level: number) => void;
   resetChairLevels: () => void;
+  /** Desk owner email → monitor upgrade count (0–7); synced from server. */
+  monitorLevelByEmail: Record<string, number>;
+  setDeskMonitorLevels: (map: Record<string, number>) => void;
+  patchMonitorLevel: (email: string, level: number) => void;
+  resetMonitorLevels: () => void;
   roomInfo: RoomInfo | null;
   setRoomInfo: (info: RoomInfo | null) => void;
 
@@ -196,9 +210,18 @@ export const useGameStore = create<GameState>((set) => ({
     let newSessionPaper = state.sessionPaper;
     let newLastPaperEarnedAt = state.lastPaperEarnedAt;
 
-    // Passive generation: 1 paper every 30 seconds during focus (derived from wall time so bursts catch up)
+    // Passive generation during focus: wall-clock based; rate scales with monitor upgrades (first 3 levels).
     if (state.timerMode === 'focus') {
-      const targetSessionPaper = Math.floor((1500 - newTimeLeft) / 30);
+      const elapsed = 1500 - newTimeLeft;
+      const email = state.user?.email;
+      const rawLv =
+        email !== undefined ? (state.monitorLevelByEmail[email] ?? 0) : 0;
+      const monitorLv = Math.min(
+        MONITOR_UPGRADE_MAX_LEVEL,
+        Math.max(0, Math.floor(rawLv))
+      );
+      const reamsPerMin = focusReamsPerMinute(monitorLv);
+      const targetSessionPaper = Math.floor((elapsed * reamsPerMin) / 60);
       const paperDelta = targetSessionPaper - state.sessionPaper;
       if (paperDelta > 0) {
         newPaperReams += paperDelta;
@@ -231,6 +254,9 @@ export const useGameStore = create<GameState>((set) => ({
   isChatFocused: false,
   occupiedDeskIds: [],
   user: null,
+  playerProfileLoaded: false,
+  playerProfileDisplayName: null,
+  playerProfileJobTitle: null,
   avatarConfig: (() => {
     try {
       const stored = localStorage.getItem('avatar_config');
@@ -243,6 +269,12 @@ export const useGameStore = create<GameState>((set) => ({
   setChatFocused: (focused) => set({ isChatFocused: focused }),
   setOccupiedDeskIds: (ids) => set({ occupiedDeskIds: ids }),
   setUser: (user) => set({ user }),
+  setPlayerProfileFromServer: (profile) =>
+    set({
+      playerProfileLoaded: true,
+      playerProfileDisplayName: profile.displayName,
+      playerProfileJobTitle: profile.jobTitle,
+    }),
   setAvatarConfig: (config) => {
     localStorage.setItem('avatar_config', JSON.stringify(config));
     set({ avatarConfig: config });
@@ -257,6 +289,14 @@ export const useGameStore = create<GameState>((set) => ({
       chairLevelByEmail: { ...s.chairLevelByEmail, [email]: level },
     })),
   resetChairLevels: () => set({ chairLevelByEmail: {} }),
+  monitorLevelByEmail: {},
+  setDeskMonitorLevels: (map) =>
+    set((s) => ({ monitorLevelByEmail: { ...s.monitorLevelByEmail, ...map } })),
+  patchMonitorLevel: (email, level) =>
+    set((s) => ({
+      monitorLevelByEmail: { ...s.monitorLevelByEmail, [email]: level },
+    })),
+  resetMonitorLevels: () => set({ monitorLevelByEmail: {} }),
   roomInfo: null,
   setRoomInfo: (info) => set({ roomInfo: info }),
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,8 @@ export type RoomRole = 'admin' | 'manager' | 'worker';
 export interface RoomMember {
   email: string;
   name: string | null;
+  /** Job title from `users.job_title`; optional for older API payloads. */
+  jobTitle?: string | null;
   role: RoomRole;
   isOnline?: boolean;
 }


### PR DESCRIPTION
Profile & database. Players set a display name and optional job title on the Edit Avatar screen. Names map to the existing users.display_name column; titles use a new nullable users.job_title column. GET /api/player returns both fields; POST /api/avatar saves appearance plus profile text (length limits and sanitization on the server). On join room, display_name is only seeded from auth when empty, so custom names are not overwritten.

Multiplayer & chat. Socket Player.name uses the resolved display name from the database, so 3D name tags, other clients, and chat stay consistent with the saved profile.

Leaderboard & admin. Room leaderboard, conference whiteboard top seller, and room admin member list show name + job title where applicable.

Desks. Working-area desk billboards prefer roomInfo.members for the owner’s current display name and show {Name}'s desk, falling back to layout ownerName or the email local part if needed.

Other changes in the same branch include monitor upgrade shared constants, VendingMenu / Pomodoro / useSocket updates, and small constants tweaks that were part of the same working tree when the PR was opened.

How to verify. Edit name/title on the landing Edit Avatar flow, rejoin a room, confirm your tag, chat prefix, leaderboard line, and desk label; optional: LOCAL_TEST / Postgres paths for API and job_title migration.