### PR TITLE
feat: extra focus energy regen during water cooler buff

### DIFF
--- a/src/components/world/break-room/props/WaterCooler.tsx
+++ b/src/components/world/break-room/props/WaterCooler.tsx
@@ -2,11 +2,10 @@ import React, { useRef } from 'react';
 import { Box, Cylinder, Billboard, Text } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
+import { FOCUS_ENERGY_WATER_BUFF_DURATION_MS } from '../../../../focusEnergyModel';
 import { WATER_COOLER_RADIUS } from '../../../../officeLayout';
 import { useGameStore } from '../../../../store/useGameStore';
 import { onOverlayTextSync } from '../../../../utils/overlayTextSync';
-
-const FIVE_MIN_MS = 5 * 60 * 1000;
 
 export const WaterCooler = ({
   position,
@@ -35,7 +34,7 @@ export const WaterCooler = ({
 
     const gs = useGameStore.getState();
     if (near && !wasNearRef.current) {
-      gs.setWaterBuffExpiresAt(Date.now() + FIVE_MIN_MS);
+      gs.setWaterBuffExpiresAt(Date.now() + FOCUS_ENERGY_WATER_BUFF_DURATION_MS);
     }
     wasNearRef.current = near;
 

--- a/src/focusEnergyModel.ts
+++ b/src/focusEnergyModel.ts
@@ -6,6 +6,12 @@ export const FOCUS_ENERGY_MAX = 100;
 export const FOCUS_ENERGY_DRAIN_PER_MIN = 2;
 export const FOCUS_ENERGY_REGEN_PER_MIN = 5;
 
+/** Extra focus energy regen per minute while the local water-cooler buff is active (client-only). */
+export const FOCUS_ENERGY_WATER_BUFF_REGEN_PER_MIN = 5;
+
+/** Must match water cooler buff length in `WaterCooler.tsx` (enter radius → expires). */
+export const FOCUS_ENERGY_WATER_BUFF_DURATION_MS = 5 * 60 * 1000;
+
 /**
  * While seated in a focus session, each chair upgrade level adds this much energy per minute
  * (stacks with {@link FOCUS_ENERGY_DRAIN_PER_MIN} — net change is drain minus this bonus).
@@ -55,6 +61,23 @@ export function isFocusEnergyInDecayZone(energy: number): boolean {
 export function parseFocusEnergyMode(raw: unknown): FocusEnergyMode {
   if (raw === "focus") return "focus";
   return "idle";
+}
+
+/**
+ * Minutes within `[fromMs, toMs]` that overlap the water buff window ending at `buffExpiresAt`.
+ * Buff is assumed active on `[buffExpiresAt - {@link FOCUS_ENERGY_WATER_BUFF_DURATION_MS}, buffExpiresAt]`.
+ */
+export function waterBuffOverlapMinutes(
+  fromMs: number,
+  toMs: number,
+  buffExpiresAt: number | null
+): number {
+  if (buffExpiresAt == null || toMs <= fromMs) return 0;
+  const winStart = buffExpiresAt - FOCUS_ENERGY_WATER_BUFF_DURATION_MS;
+  const a = Math.max(fromMs, winStart);
+  const b = Math.min(toMs, buffExpiresAt);
+  if (b <= a) return 0;
+  return (b - a) / 60_000;
 }
 
 /**

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -3,7 +3,9 @@ import { FOCUS_SIT_POSE_COUNT } from '../avatarFocusPoses';
 import {
   clampFocusEnergy,
   focusReamMultiplier,
+  FOCUS_ENERGY_WATER_BUFF_REGEN_PER_MIN,
   settleFocusEnergy,
+  waterBuffOverlapMinutes,
 } from '../focusEnergyModel';
 import { CHAIR_UPGRADE_MAX_LEVEL } from '../chairUpgradeConstants';
 import { MONITOR_UPGRADE_MAX_LEVEL, focusReamsPerMinute } from '../monitorUpgradeConstants';
@@ -103,7 +105,7 @@ interface GameState {
 
   nearWaterCooler: boolean;
   setNearWaterCooler: (near: boolean) => void;
-  /** Local-only UI: epoch ms when water cooler buff ends (5 min from last enter). */
+  /** Local-only: epoch ms when water cooler buff ends (extra focus regen while window overlaps wall-clock ticks). */
   waterBuffExpiresAt: number | null;
   setWaterBuffExpiresAt: (expiresAt: number | null) => void;
   showLeaderboard: boolean;
@@ -317,12 +319,10 @@ export const useGameStore = create<GameState>((set, get) => ({
         CHAIR_UPGRADE_MAX_LEVEL,
         Math.max(0, Math.floor(rawChair))
       );
-      const settled = settleFocusEnergy(
-        state.focusEnergy,
-        last,
-        now,
-        mode,
-        chairLv
+      const overlapMin = waterBuffOverlapMinutes(last, now, state.waterBuffExpiresAt);
+      const base = settleFocusEnergy(state.focusEnergy, last, now, mode, chairLv);
+      const settled = clampFocusEnergy(
+        base + FOCUS_ENERGY_WATER_BUFF_REGEN_PER_MIN * overlapMin
       );
       return { focusEnergy: settled, focusEnergyLastTickAt: now };
     }),


### PR DESCRIPTION
Apply +5 focus energy per minute for wall-clock time overlapping the
local 5-minute water buff window. Share buff duration constant between
WaterCooler and focusEnergyModel. Server settlement unchanged.

Made-with: Cursor
