### PR TITLE
feat: first-visit path tutorial (desk and vending)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { Monitor, Info } from 'lucide-react';
 
 import { useAuth } from './hooks/useAuth';
 import { useFocusSessionCompleteFeedback } from './hooks/useFocusSessionCompleteFeedback';
+import { useOfficeTutorial } from './hooks/useOfficeTutorial';
 import { useSocket } from './hooks/useSocket';
 import { getEffectiveDeskUpgradeEmail } from './deskOwner';
 import { useGameStore } from './store/useGameStore';
@@ -28,6 +29,8 @@ import { FurnitureItem } from './types';
 import { OfficeEnvironment } from './components/world/OfficeEnvironment';
 import { LocalPlayer } from './components/player/LocalPlayer';
 import { OtherPlayer } from './components/player/OtherPlayer';
+import { TutorialBanner } from './components/tutorial/TutorialBanner';
+import { TutorialPathGuide } from './components/tutorial/TutorialPathGuide';
 
 const KEYBOARD_MAP = [
   { name: 'forward', keys: ['ArrowUp', 'KeyW'] },
@@ -226,6 +229,8 @@ export default function App() {
       ? (playerProfileDisplayName?.trim() || user.name)
       : user?.name ?? '';
 
+  const officeTutorial = useOfficeTutorial(user?.email, Boolean(currentRoom));
+
   // ── Loading ──────────────────────────────────────────────────────────────
   if (authLoading) {
     return (
@@ -404,6 +409,10 @@ export default function App() {
         </div>
       )}
 
+      {officeTutorial.active && officeTutorial.phase && (
+        <TutorialBanner phase={officeTutorial.phase} onSkip={officeTutorial.skip} />
+      )}
+
       <KeyboardControls map={keyboardMap}>
         <Canvas shadows dpr={[1, 2]} camera={{ position: [0, 2, 5], fov: 50 }}>
           <color attach="background" args={['#1e293b']} />
@@ -434,6 +443,10 @@ export default function App() {
             {Object.values(players).map((player) => (
               <OtherPlayer key={player.id} player={player} />
             ))}
+            <TutorialPathGuide
+              visible={officeTutorial.active}
+              target={officeTutorial.targetPosition}
+            />
             <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
           </React.Suspense>
         </Canvas>

--- a/src/components/tutorial/TutorialBanner.tsx
+++ b/src/components/tutorial/TutorialBanner.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { OfficeTutorialPhase } from '../../hooks/useOfficeTutorial';
+
+type Props = {
+  phase: OfficeTutorialPhase;
+  onSkip: () => void;
+};
+
+const COPY: Record<OfficeTutorialPhase, string> = {
+  desk:
+    'Follow the yellow line on the floor to your desk. Stand close and press [E] to start Focus and earn reams.',
+  vending:
+    'Head to the break room vending machine (Vend-O-Matic). Spend reams on ice cream, chair upgrades, and monitor upgrades.',
+};
+
+/** Bottom-screen hints for the first-visit office tutorial (desk, then vending). */
+export function TutorialBanner({ phase, onSkip }: Props) {
+  return (
+    <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-20 flex justify-center p-4 pb-6">
+      <div className="pointer-events-auto flex max-w-lg flex-col gap-3 rounded-xl border border-amber-400/40 bg-slate-900/90 px-4 py-3 shadow-lg backdrop-blur-md sm:max-w-xl sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm leading-relaxed text-amber-50 sm:text-base">{COPY[phase]}</p>
+        <button
+          type="button"
+          onClick={onSkip}
+          className="pixel-border shrink-0 rounded bg-slate-700 px-3 py-2 font-pixel text-[10px] uppercase tracking-wide text-slate-200 transition hover:bg-slate-600 sm:text-[9px]"
+        >
+          Skip tutorial
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tutorial/TutorialPathGuide.tsx
+++ b/src/components/tutorial/TutorialPathGuide.tsx
@@ -1,0 +1,55 @@
+import React, { useRef, useState } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Line } from '@react-three/drei';
+
+const Y = 0.12;
+const THROTTLE_SEC = 0.04;
+
+type Props = {
+  target: readonly [number, number, number] | null;
+  visible: boolean;
+};
+
+/**
+ * Ground-level dashed path from local player feet to the tutorial target (drei Line).
+ */
+export function TutorialPathGuide({ target, visible }: Props) {
+  const [points, setPoints] = useState<[number, number, number][]>([
+    [0, Y, 0],
+    [0, Y, 0],
+  ]);
+  const accRef = useRef(0);
+
+  useFrame((state, dt) => {
+    if (!visible || !target) return;
+    accRef.current += dt;
+    if (accRef.current < THROTTLE_SEC) return;
+    accRef.current = 0;
+    const player = state.scene.getObjectByName('localPlayer');
+    if (!player) return;
+    const px = player.position.x;
+    const pz = player.position.z;
+    const tx = target[0];
+    const tz = target[2];
+    setPoints([
+      [px, Y, pz],
+      [tx, Y, tz],
+    ]);
+  });
+
+  if (!visible || !target) return null;
+
+  return (
+    <Line
+      points={points}
+      color="#fbbf24"
+      lineWidth={2}
+      dashed
+      dashSize={0.45}
+      gapSize={0.28}
+      renderOrder={1000}
+      depthWrite={false}
+      frustumCulled={false}
+    />
+  );
+}

--- a/src/hooks/useOfficeTutorial.ts
+++ b/src/hooks/useOfficeTutorial.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { VENDING_MACHINE_WORLD_POSITION } from '../officeLayout';
+import { useGameStore } from '../store/useGameStore';
+import type { DeskItem, FurnitureItem } from '../types';
+
+export type OfficeTutorialPhase = 'desk' | 'vending';
+
+const STORAGE_PREFIX = 'office_tutorial_v1:';
+
+function tutorialStorageKey(email: string) {
+  return `${STORAGE_PREFIX}${email}`;
+}
+
+export function isOfficeTutorialComplete(email: string | undefined): boolean {
+  if (!email || typeof localStorage === 'undefined') return true;
+  return localStorage.getItem(tutorialStorageKey(email)) === '1';
+}
+
+function markOfficeTutorialComplete(email: string) {
+  localStorage.setItem(tutorialStorageKey(email), '1');
+}
+
+/** Returns world position of the desk owned by `email`, if present in the layout. */
+function findMyDeskPosition(layout: FurnitureItem[], email: string): [number, number, number] | null {
+  const id = `desk-${email}`;
+  const item = layout.find((f): f is DeskItem => f.type === 'desk' && f.id === id);
+  if (!item) return null;
+  const [x, y, z] = item.position;
+  return [x, y, z];
+}
+
+/**
+ * First-visit path tutorial: desk (focus / reams) then vending machine.
+ * Pauses while Pomodoro focus is active. Persists completion per email in localStorage.
+ * Only active while `inRoom` is true (layout in the store may outlive the current room).
+ */
+export function useOfficeTutorial(email: string | undefined, inRoom: boolean) {
+  const roomLayout = useGameStore((s) => s.roomLayout);
+  const nearestDeskId = useGameStore((s) => s.nearestDeskId);
+  const nearVendingMachine = useGameStore((s) => s.nearVendingMachine);
+  const showVendingMenu = useGameStore((s) => s.showVendingMenu);
+  const isTimerActive = useGameStore((s) => s.isTimerActive);
+
+  const [phase, setPhase] = useState<OfficeTutorialPhase | null>(null);
+  const openedVendingInStepRef = useRef(false);
+  const prevPhaseRef = useRef<OfficeTutorialPhase | null>(null);
+
+  const myDeskPosition = useMemo(
+    () => (email ? findMyDeskPosition(roomLayout, email) : null),
+    [email, roomLayout]
+  );
+
+  useEffect(() => {
+    openedVendingInStepRef.current = false;
+  }, [email]);
+
+  useEffect(() => {
+    if (!inRoom) {
+      setPhase(null);
+      return;
+    }
+    if (!email || isOfficeTutorialComplete(email)) {
+      setPhase(null);
+      return;
+    }
+    if (!myDeskPosition) {
+      setPhase(null);
+      return;
+    }
+    setPhase((prev) => {
+      if (prev === 'vending') return prev;
+      return 'desk';
+    });
+  }, [inRoom, email, myDeskPosition]);
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    prevPhaseRef.current = phase;
+    if (prev !== 'vending' && phase === 'vending') {
+      openedVendingInStepRef.current = false;
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase === 'vending' && showVendingMenu) {
+      openedVendingInStepRef.current = true;
+    }
+  }, [phase, showVendingMenu]);
+
+  useEffect(() => {
+    if (!email || phase !== 'desk') return;
+    if (nearestDeskId === `desk-${email}`) {
+      setPhase('vending');
+    }
+  }, [email, phase, nearestDeskId]);
+
+  useEffect(() => {
+    if (!email || phase !== 'vending') return;
+    if (nearVendingMachine || openedVendingInStepRef.current) {
+      markOfficeTutorialComplete(email);
+      setPhase(null);
+    }
+  }, [email, phase, nearVendingMachine, showVendingMenu]);
+
+  const skip = useCallback(() => {
+    if (email) markOfficeTutorialComplete(email);
+    setPhase(null);
+  }, [email]);
+
+  const visible = inRoom && phase !== null && !isTimerActive;
+  const targetPosition: [number, number, number] | null =
+    !visible || !phase
+      ? null
+      : phase === 'desk'
+        ? myDeskPosition
+        : [...VENDING_MACHINE_WORLD_POSITION] as [number, number, number];
+
+  return {
+    active: visible,
+    phase: visible ? phase : null,
+    targetPosition,
+    skip,
+  };
+}

--- a/src/officeLayout.ts
+++ b/src/officeLayout.ts
@@ -36,5 +36,12 @@ export const WATER_COOLER_RADIUS = 2.5;
 /** Vending machine position local to the break room group (east side). */
 export const VENDING_MACHINE_LOCAL_POSITION: [number, number, number] = [13, 0, 0];
 
+/** Vending machine center in world space (break room group + local). */
+export const VENDING_MACHINE_WORLD_POSITION: [number, number, number] = [
+  BREAK_ROOM_GROUP_POSITION[0] + VENDING_MACHINE_LOCAL_POSITION[0],
+  BREAK_ROOM_GROUP_POSITION[1] + VENDING_MACHINE_LOCAL_POSITION[1],
+  BREAK_ROOM_GROUP_POSITION[2] + VENDING_MACHINE_LOCAL_POSITION[2],
+];
+
 /** Horizontal proximity radius for Vend-O-Matic interactions (meters). */
 export const VENDING_MACHINE_RADIUS = 2.5;


### PR DESCRIPTION
## Summary
Adds a first-visit onboarding flow that guides new players to their desk (Focus / reams) and then to the break room vending machine, using a dashed floor path (drei Line) and a bottom banner.

## Details
- \VENDING_MACHINE_WORLD_POSITION\ in \officeLayout.ts\ for a stable tutorial target
- \useOfficeTutorial\: two phases, \localStorage\ key \office_tutorial_v1:<email>\, hidden during Pomodoro focus, only active while in a room
- \TutorialPathGuide\ + \TutorialBanner\ (English copy)
- Skip control marks the tutorial complete

## Test plan
- Clear \localStorage\ key for your email, join a room: yellow path to desk, then to vending; complete or skip persists.

Made with [Cursor](https://cursor.com)