### PR TITLE
feat: Team Pyramid vending room buff and floating Sabre tablet

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,10 @@ import {
   MONITOR_UPGRADE_MAX_LEVEL,
   monitorUpgradeCostForNextLevel,
 } from "./src/monitorUpgradeConstants.js";
+import {
+  TEAM_PYRAMID_COST_REAMS,
+  TEAM_PYRAMID_DURATION_MS,
+} from "./src/gameConfig.js";
 import { totalPaperReamsEarnedFloor } from "./src/paperReamsLifetime.js";
 import {
   FOCUS_ENERGY_MAX,
@@ -483,6 +487,57 @@ async function purchaseMonitorUpgradeTxn(email: string): Promise<MonitorPurchase
     );
     await client.query("COMMIT");
     return { ok: true, paperReams: newPaper, monitorUpgradeLevel: newLevel };
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+type TeamPyramidPurchaseResult =
+  | { ok: true; paperReams: number }
+  | { ok: false; error: "insufficient" };
+
+async function purchaseTeamPyramidTxn(email: string): Promise<TeamPyramidPurchaseResult> {
+  if (isLocalTest()) {
+    return mem.memPurchaseTeamPyramid(email);
+  }
+  const client = await pool!.connect();
+  try {
+    await client.query("BEGIN");
+    const sel = await client.query(
+      `SELECT paper_reams,
+              COALESCE(chair_upgrade_level, 0) AS chair_upgrade_level,
+              COALESCE(monitor_upgrade_level, 0) AS monitor_upgrade_level
+       FROM users WHERE email = $1 FOR UPDATE`,
+      [email]
+    );
+    if (sel.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "insufficient" };
+    }
+    const paper = sel.rows[0].paper_reams as number;
+    if (paper < TEAM_PYRAMID_COST_REAMS) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "insufficient" };
+    }
+    const newPaper = paper - TEAM_PYRAMID_COST_REAMS;
+    const chairLv = Number(sel.rows[0].chair_upgrade_level);
+    const monitorLv = Number(sel.rows[0].monitor_upgrade_level);
+    const floor = totalPaperReamsEarnedFloor(newPaper, chairLv, monitorLv);
+    await client.query(
+      `UPDATE users SET paper_reams = $1,
+         total_paper_reams_earned = GREATEST(total_paper_reams_earned, $3)
+       WHERE email = $2`,
+      [newPaper, email, floor]
+    );
+    await client.query("COMMIT");
+    return { ok: true, paperReams: newPaper };
   } catch (err) {
     try {
       await client.query("ROLLBACK");
@@ -1119,6 +1174,16 @@ export async function createApp(injectedPool?: pg.Pool) {
   // Player state grouped by room
 const rooms: Record<string, Record<string, any>> = {};
 
+/** Per-room Team Pyramid buff expiry (epoch ms). In-memory only. */
+const roomTeamPyramidBuffExpiresAt: Record<string, number> = {};
+
+function activeTeamPyramidBuffExpiresAt(roomId: string): number | null {
+  const raw = roomTeamPyramidBuffExpiresAt[roomId];
+  if (typeof raw !== "number" || !Number.isFinite(raw)) return null;
+  if (Date.now() >= raw) return null;
+  return raw;
+}
+
 const OFFICE_COLORS = [
   "#4f46e5", // Indigo
   "#059669", // Emerald
@@ -1210,6 +1275,10 @@ io.on("connection", (socket) => {
 
       // Send current players in this room to the new player
       socket.emit("currentPlayers", rooms[room]);
+
+      socket.emit("teamPyramidBuffLoaded", {
+        expiresAt: activeTeamPyramidBuffExpiresAt(room),
+      });
 
       // Broadcast new player to others in the same room
       socket.to(room).emit("newPlayer", rooms[room][socket.id]);
@@ -1369,6 +1438,44 @@ io.on("connection", (socket) => {
           });
         } catch (e) {
           console.error("purchaseMonitorUpgrade:", e);
+          respond({ ok: false, error: "server_error" });
+        }
+      }
+    );
+
+    socket.on(
+      "purchaseTeamPyramid",
+      async (ack: (r: unknown) => void) => {
+        const respond = typeof ack === "function" ? ack : () => {};
+        let playerRoom = "";
+        for (const roomId in rooms) {
+          if (rooms[roomId][socket.id]) {
+            playerRoom = roomId;
+            break;
+          }
+        }
+        if (!playerRoom) {
+          respond({ ok: false, error: "not_in_room" });
+          return;
+        }
+        try {
+          await ensureUserRow(user.email);
+          const result = await purchaseTeamPyramidTxn(user.email);
+          if (!result.ok) {
+            respond(result);
+            return;
+          }
+          const expiresAt = Date.now() + TEAM_PYRAMID_DURATION_MS;
+          roomTeamPyramidBuffExpiresAt[playerRoom] = expiresAt;
+          socket.emit("paperReamsLoaded", result.paperReams);
+          io.to(playerRoom).emit("teamPyramidBuffUpdated", { expiresAt });
+          respond({
+            ok: true,
+            paperReams: result.paperReams,
+            expiresAt,
+          });
+        } catch (e) {
+          console.error("purchaseTeamPyramid:", e);
           respond({ ok: false, error: "server_error" });
         }
       }

--- a/server/memoryDb.ts
+++ b/server/memoryDb.ts
@@ -1,6 +1,7 @@
 /** In-memory DB for LOCAL_TEST=1 only. Not used when PostgreSQL is active. */
 
 import { MONITOR_UPGRADE_MAX_LEVEL, monitorUpgradeCostForNextLevel } from "../src/monitorUpgradeConstants.js";
+import { TEAM_PYRAMID_COST_REAMS } from "../src/gameConfig.js";
 import { totalPaperReamsEarnedFloor } from "../src/paperReamsLifetime.js";
 import {
   clampFocusEnergy,
@@ -407,6 +408,22 @@ export async function memPurchaseMonitorUpgrade(email: string): Promise<MemMonit
   );
   users.set(email, u);
   return { ok: true, paperReams: u.paper_reams, monitorUpgradeLevel: u.monitor_upgrade_level };
+}
+
+export type MemTeamPyramidPurchaseResult =
+  | { ok: true; paperReams: number }
+  | { ok: false; error: "insufficient" };
+
+export async function memPurchaseTeamPyramid(email: string): Promise<MemTeamPyramidPurchaseResult> {
+  const u = users.get(email) ?? defaultUserRow();
+  if (u.paper_reams < TEAM_PYRAMID_COST_REAMS) return { ok: false, error: "insufficient" };
+  u.paper_reams -= TEAM_PYRAMID_COST_REAMS;
+  u.total_paper_reams_earned = Math.max(
+    u.total_paper_reams_earned,
+    totalPaperReamsEarnedFloor(u.paper_reams, u.chair_upgrade_level, u.monitor_upgrade_level)
+  );
+  users.set(email, u);
+  return { ok: true, paperReams: u.paper_reams };
 }
 
 export async function memUpdateRoomMaxWorkers(roomId: string, maxWorkers: number): Promise<void> {

--- a/src/__tests__/unit/gameStore.test.ts
+++ b/src/__tests__/unit/gameStore.test.ts
@@ -23,6 +23,7 @@ function resetStore() {
     monitorLevelByEmail: {},
     roomLayout: [],
     user: undefined,
+    teamPyramidBuffExpiresAt: null,
   });
 }
 
@@ -158,6 +159,16 @@ describe('useGameStore — tickTimer', () => {
     useGameStore.getState().tickTimer();
     expect(useGameStore.getState().sessionPaper).toBe(1);
     expect(useGameStore.getState().paperReams).toBe(1);
+  });
+
+  it('applies Team Pyramid buff (+50% reams/min) during focus', () => {
+    useGameStore.setState({ teamPyramidBuffExpiresAt: 1e15 });
+    useGameStore.getState().startTimer('focus');
+    vi.advanceTimersByTime(20 * 1000);
+    useGameStore.getState().tickTimer();
+    // Baseline 2/min → 0 whole reams in 20s; with ×1.5 → 3/min → 1 whole ream in 20s.
+    expect(useGameStore.getState().paperReams).toBe(1);
+    expect(useGameStore.getState().sessionPaper).toBe(1);
   });
 
   it('awards 2 papers after 60 seconds of focus', () => {

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -8,7 +8,7 @@ import { getDeterministicColor, COLLISION_BOXES, ROLL_PIVOT_Y } from '../../cons
 import { useGameStore } from '../../store/useGameStore';
 import { DEFAULT_AVATAR_CONFIG } from '../../types';
 import { usePlayerPhysics, usePlayerPhysicsAvatarSync } from '../../hooks/usePlayerPhysics';
-import { MS_BODY_THROWABLE_ID } from '../../propIds';
+import { MS_BODY_THROWABLE_ID, TEAM_PYRAMID_INSPECT_ID } from '../../propIds';
 import { iceCreamColorForIndex } from '../../iceCreamFlavors';
 import { CharacterAvatar } from './CharacterAvatar';
 import { WaterEnergyAura } from './WaterEnergyAura';
@@ -217,8 +217,10 @@ export const LocalPlayer = ({
         }
         interactConsumed = true;
       } else if (nearThrowableId !== null) {
-        pickUpObject(nearThrowableId);
-        emitHeldThrowableSync(socket, nearThrowableId);
+        if (nearThrowableId !== TEAM_PYRAMID_INSPECT_ID) {
+          pickUpObject(nearThrowableId);
+          emitHeldThrowableSync(socket, nearThrowableId);
+        }
         interactConsumed = true;
       }
     }

--- a/src/components/ui/InspectOverlay.tsx
+++ b/src/components/ui/InspectOverlay.tsx
@@ -3,11 +3,11 @@ import { Canvas } from '@react-three/fiber';
 import { OrbitControls, useGLTF, Bounds, Center, useBounds } from '@react-three/drei';
 import { useGameStore } from '../../store/useGameStore';
 import { ASSET_PATHS, AssetKey } from '../../hooks/useGameAsset';
+import { TeamPyramidTabletMesh } from '../world/working-area/TeamPyramidTabletMesh';
 
 // ─── 3D model viewer ─────────────────────────────────────────────────────────
 
-function InspectModel({ assetKey }: { assetKey: string }) {
-  const path = ASSET_PATHS[assetKey as AssetKey];
+function InspectModelInner({ path }: { path: string }) {
   const { scene } = useGLTF(path);
   const bounds = useBounds();
 
@@ -31,6 +31,7 @@ function InspectModel({ assetKey }: { assetKey: string }) {
 }
 
 function InspectScene({ assetKey }: { assetKey: string }) {
+  const path = ASSET_PATHS[assetKey as AssetKey];
   return (
     <Canvas camera={{ position: [0, 0, 5], fov: 45 }}>
       <ambientLight intensity={1.2} />
@@ -42,7 +43,33 @@ function InspectScene({ assetKey }: { assetKey: string }) {
             Center ensures the geometry sits at the world origin. */}
         <Bounds fit clip observe margin={1.2}>
           <Center>
-            <InspectModel assetKey={assetKey} />
+            {path ? <InspectModelInner path={path} /> : null}
+          </Center>
+        </Bounds>
+      </Suspense>
+      <OrbitControls
+        autoRotate
+        autoRotateSpeed={1.8}
+        enableZoom={false}
+        enablePan={false}
+        minPolarAngle={Math.PI / 6}
+        maxPolarAngle={Math.PI / 1.8}
+        makeDefault
+      />
+    </Canvas>
+  );
+}
+
+function PyramidInspectScene() {
+  return (
+    <Canvas camera={{ position: [0, 0.2, 2.6], fov: 42 }}>
+      <ambientLight intensity={1.1} />
+      <directionalLight position={[2, 5, 3]} intensity={1.8} />
+      <directionalLight position={[-2, 2, -2]} intensity={0.5} />
+      <Suspense fallback={null}>
+        <Bounds fit clip observe margin={1.2}>
+          <Center>
+            <TeamPyramidTabletMesh />
           </Center>
         </Bounds>
       </Suspense>
@@ -98,7 +125,11 @@ export function InspectOverlay() {
 
         {/* 3D canvas — left half */}
         <div className="w-1/2 h-full flex-shrink-0">
-          <InspectScene assetKey={inspectedObject.assetKey} />
+          {inspectedObject.previewKind === 'pyramid' ? (
+            <PyramidInspectScene />
+          ) : (
+            <InspectScene assetKey={inspectedObject.assetKey} />
+          )}
         </div>
 
         {/* Info — right half */}
@@ -109,6 +140,30 @@ export function InspectOverlay() {
           <p className="text-slate-300 text-sm leading-relaxed">
             {inspectedObject.description}
           </p>
+          {(inspectedObject.linkUrl || inspectedObject.secondaryLinkUrl) && (
+            <div className="flex flex-col gap-2">
+              {inspectedObject.linkUrl ? (
+                <a
+                  href={inspectedObject.linkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-violet-400 hover:text-violet-300 text-sm font-medium underline underline-offset-2"
+                >
+                  {inspectedObject.linkLabel ?? 'Open link'}
+                </a>
+              ) : null}
+              {inspectedObject.secondaryLinkUrl ? (
+                <a
+                  href={inspectedObject.secondaryLinkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-violet-400 hover:text-violet-300 text-sm font-medium underline underline-offset-2"
+                >
+                  {inspectedObject.secondaryLinkLabel ?? 'Open link'}
+                </a>
+              ) : null}
+            </div>
+          )}
           <p className="text-slate-500 text-xs mt-auto">
             Press [F] or [Esc] to close
           </p>

--- a/src/components/ui/PomodoroUI.tsx
+++ b/src/components/ui/PomodoroUI.tsx
@@ -4,6 +4,7 @@ import { Timer, Coffee, Play, Square, Pause } from 'lucide-react';
 import { getEffectiveDeskUpgradeEmail } from '../../deskOwner';
 import { focusReamMultiplier } from '../../focusEnergyModel';
 import { focusReamsPerMinute } from '../../monitorUpgradeConstants';
+import { TEAM_PYRAMID_FOCUS_REAM_MULTIPLIER } from '../../gameConfig';
 import { useGameStore } from '../../store/useGameStore';
 import { FocusEnergyBar } from './FocusEnergyBar';
 
@@ -23,6 +24,7 @@ export const PomodoroUI = () => {
     user,
     monitorLevelByEmail,
     focusEnergy,
+    teamPyramidBuffExpiresAt,
   } = useGameStore();
   const upgradeEmail = getEffectiveDeskUpgradeEmail(
     roomLayout,
@@ -33,8 +35,13 @@ export const PomodoroUI = () => {
     upgradeEmail !== undefined
       ? focusReamsPerMinute(monitorLevelByEmail[upgradeEmail] ?? 0)
       : focusReamsPerMinute(0);
-  const focusEarnPerMin =
-    Math.round(baseFocusPerMin * focusReamMultiplier(focusEnergy) * 10) / 10;
+  const teamPyramidActive =
+    teamPyramidBuffExpiresAt != null &&
+    Number.isFinite(teamPyramidBuffExpiresAt) &&
+    Date.now() < teamPyramidBuffExpiresAt;
+  let focusEarnPerMin =
+    baseFocusPerMin * focusReamMultiplier(focusEnergy) * (teamPyramidActive ? TEAM_PYRAMID_FOCUS_REAM_MULTIPLIER : 1);
+  focusEarnPerMin = Math.round(focusEarnPerMin * 10) / 10;
 
   useEffect(() => {
     if (!isTimerActive || isTimerPaused) return;
@@ -93,6 +100,16 @@ export const PomodoroUI = () => {
                 <div className="text-indigo-300 text-[10px] uppercase tracking-[0.2em] font-bold animate-pulse text-center">
                   {isTimerPaused ? 'Session Paused' : 'Stay Focused on your real tasks...'}
                 </div>
+                {teamPyramidActive && !isTimerPaused && (
+                  <div className="flex flex-col items-center gap-0.5 text-center px-1">
+                    <div className="text-fuchsia-300/95 text-[10px] uppercase tracking-[0.18em] font-bold">
+                      Power of The Pyramid
+                    </div>
+                    <div className="text-fuchsia-200/85 text-[9px] font-medium leading-snug italic">
+                      With the pyramid you have the connection to everything, in time, and space!
+                    </div>
+                  </div>
+                )}
                 <div className="text-slate-400 font-mono text-[10px]">
                   Earn rate:{' '}
                   <span className="text-cyan-300/90">

--- a/src/components/ui/VendingMenu.tsx
+++ b/src/components/ui/VendingMenu.tsx
@@ -16,7 +16,11 @@ import {
   FOCUS_ENERGY_SEATED_REGEN_PER_CHAIR_LEVEL_PER_MIN,
 } from '../../focusEnergyModel';
 
-import { ICE_CREAM_COST_REAMS, ICE_CREAM_DURATION_MS } from '../../gameConfig';
+import {
+  ICE_CREAM_COST_REAMS,
+  ICE_CREAM_DURATION_MS,
+  TEAM_PYRAMID_COST_REAMS,
+} from '../../gameConfig';
 
 interface VendingMenuProps {
   onClose: () => void;
@@ -31,6 +35,10 @@ type MonitorPurchaseAck =
   | { ok: true; paperReams: number; monitorUpgradeLevel: number }
   | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
 
+type TeamPyramidPurchaseAck =
+  | { ok: true; paperReams: number; expiresAt: number }
+  | { ok: false; error: 'insufficient' | 'not_in_room' | 'server_error' };
+
 export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const paperReams = useGameStore((s) => s.paperReams);
   const addPaper = useGameStore((s) => s.addPaper);
@@ -41,6 +49,7 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const patchChairLevel = useGameStore((s) => s.patchChairLevel);
   const monitorLevelByEmail = useGameStore((s) => s.monitorLevelByEmail);
   const patchMonitorLevel = useGameStore((s) => s.patchMonitorLevel);
+  const setTeamPyramidBuffExpiresAt = useGameStore((s) => s.setTeamPyramidBuffExpiresAt);
   const [subView, setSubView] = useState<'main' | 'flavor'>('main');
   const [selectedFlavor, setSelectedFlavor] = useState(0);
   const [feedback, setFeedback] = useState<'insufficient' | 'offline' | null>(null);
@@ -51,6 +60,10 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const [monitorBusy, setMonitorBusy] = useState(false);
   const [monitorFeedback, setMonitorFeedback] = useState<
     'insufficient' | 'max_level' | 'offline' | 'not_in_room' | 'server_error' | null
+  >(null);
+  const [pyramidBusy, setPyramidBusy] = useState(false);
+  const [pyramidFeedback, setPyramidFeedback] = useState<
+    'insufficient' | 'offline' | 'not_in_room' | 'server_error' | null
   >(null);
 
   useEffect(() => {
@@ -79,6 +92,7 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const monitorMaxed = myMonitorLevel >= MONITOR_UPGRADE_MAX_LEVEL;
   const nextMonitorCost = monitorMaxed ? 0 : monitorUpgradeCostForNextLevel(myMonitorLevel);
   const canAffordMonitor = !monitorMaxed && paperReams >= nextMonitorCost;
+  const canAffordPyramid = paperReams >= TEAM_PYRAMID_COST_REAMS;
 
   const openFlavorSubmenu = () => {
     setFeedback(null);
@@ -180,6 +194,41 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
     });
   };
 
+  const handleBuyTeamPyramid = () => {
+    setPyramidFeedback(null);
+    if (!socket?.connected) {
+      setPyramidFeedback('offline');
+      return;
+    }
+    if (!canAffordPyramid) {
+      setPyramidFeedback('insufficient');
+      return;
+    }
+    setPyramidBusy(true);
+    socket.timeout(12_000).emit('purchaseTeamPyramid', (socketErr: Error | null, res: unknown) => {
+      setPyramidBusy(false);
+      if (socketErr) {
+        setPyramidFeedback('server_error');
+        return;
+      }
+      const r = res as TeamPyramidPurchaseAck;
+      if (!r || typeof r !== 'object' || !('ok' in r)) {
+        setPyramidFeedback('server_error');
+        return;
+      }
+      if (r.ok === true) {
+        setPaperReams(r.paperReams);
+        setTeamPyramidBuffExpiresAt(r.expiresAt);
+        onClose();
+        return;
+      }
+      const fail = r.error;
+      if (fail === 'insufficient') setPyramidFeedback('insufficient');
+      else if (fail === 'not_in_room') setPyramidFeedback('not_in_room');
+      else setPyramidFeedback('server_error');
+    });
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
@@ -233,6 +282,48 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
             >
               Buy ice cream
             </button>
+
+            <div className="border-2 border-fuchsia-600/45 bg-fuchsia-950/30 p-4 mb-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-pixel text-[8px] sm:text-[10px] text-fuchsia-100 mb-1">Team Pyramid</p>
+                  <p className="text-slate-400 text-[10px] sm:text-xs font-mono leading-snug">
+                    Team-wide buff: 3 hours of +50% paper reams for everyone while focusing. A floating
+                    sabre pyramid tablet appears above the office. Unleash the power of the pyramid!
+                  </p>
+                </div>
+                <span className="font-mono text-fuchsia-300 text-sm shrink-0">
+                  {TEAM_PYRAMID_COST_REAMS} reams
+                </span>
+              </div>
+            </div>
+
+            <button
+              type="button"
+              onClick={handleBuyTeamPyramid}
+              disabled={!socketOk || pyramidBusy}
+              className="pixel-button font-pixel text-[8px] sm:text-[10px] text-center w-full mb-5 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {pyramidBusy ? 'Processing…' : `Buy Team Pyramid (${TEAM_PYRAMID_COST_REAMS} reams)`}
+            </button>
+            {pyramidFeedback === 'insufficient' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mb-4 -mt-3">Not enough reams.</p>
+            )}
+            {pyramidFeedback === 'not_in_room' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mb-4 -mt-3">
+                Join the office room first.
+              </p>
+            )}
+            {pyramidFeedback === 'server_error' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mb-4 -mt-3">
+                Could not complete purchase — try again.
+              </p>
+            )}
+            {pyramidFeedback === 'offline' && (
+              <p className="text-center text-rose-400/90 text-xs font-mono mb-4 -mt-3">
+                Not connected — try again when online.
+              </p>
+            )}
 
             <div className="border-2 border-amber-600/40 bg-amber-950/25 p-4 mb-4">
               <div className="flex items-center justify-between gap-4">

--- a/src/components/world/OfficeEnvironment.tsx
+++ b/src/components/world/OfficeEnvironment.tsx
@@ -7,6 +7,7 @@ import { ManagersOffice } from './managers-office/ManagersOffice';
 import { DundieAward } from './managers-office/props/DundieAward';
 import { DwightBobblehead } from './managers-office/props/DwightBobblehead';
 import { MsBodySuit } from './managers-office/props/MsBodySuit';
+import { TeamPyramidProp } from './working-area/TeamPyramidProp';
 
 export const OfficeEnvironment = () => (
   <group>
@@ -35,6 +36,7 @@ export const OfficeEnvironment = () => (
     </Box>
 
     <WorkingArea />
+    <TeamPyramidProp />
     <BreakRoom />
     <ConferenceRoom />
     <ManagersOffice />

--- a/src/components/world/working-area/TeamPyramidProp.tsx
+++ b/src/components/world/working-area/TeamPyramidProp.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Billboard, Text } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+import {
+  TEAM_PYRAMID_INSPECT_RADIUS,
+  TEAM_PYRAMID_WORLD_POSITION,
+} from '../../../officeLayout';
+import { TEAM_PYRAMID_INSPECT_ID } from '../../../propIds';
+import { useGameStore } from '../../../store/useGameStore';
+import { onOverlayTextSync } from '../../../utils/overlayTextSync';
+import { TeamPyramidTabletMesh } from './TeamPyramidTabletMesh';
+
+const TEAM_PYRAMID_VIDEO_URL = 'https://www.youtube.com/watch?v=yZBVnjXp7GQ';
+const TEAM_PYRAMID_VIDEO_URL_ALT = 'https://www.youtube.com/watch?v=800IKHVVIH4';
+
+const INSPECT_DESCRIPTION =
+  'The Sabre Pyramid from The Office — ' +
+  'the device that was going to replace paper forever. ' +
+  'While this is active, everyone in the room earns 50% more paper reams during focus sessions. ' +
+  'Below are clips from the show for context.';
+
+/**
+ * Floating inspect-only prop when the room Team Pyramid buff is active.
+ */
+export function TeamPyramidProp() {
+  const groupRef = useRef<THREE.Group>(null);
+  const worldPos = useRef(new THREE.Vector3());
+  const expiresAt = useGameStore((s) => s.teamPyramidBuffExpiresAt);
+  const setNearThrowable = useGameStore((s) => s.setNearThrowable);
+  const setTeamPyramidBuffExpiresAt = useGameStore((s) => s.setTeamPyramidBuffExpiresAt);
+  const nearThrowableId = useGameStore((s) => s.nearThrowableId);
+  const [, setUiTick] = useState(0);
+
+  useEffect(() => {
+    if (expiresAt == null) return;
+    const id = window.setInterval(() => setUiTick((t) => t + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [expiresAt]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.code !== 'KeyF') return;
+      const s = useGameStore.getState();
+      if (s.nearThrowableId !== TEAM_PYRAMID_INSPECT_ID) return;
+      if (s.isChatFocused || s.inspectedObject !== null) return;
+      s.openInspect({
+        id: TEAM_PYRAMID_INSPECT_ID,
+        label: 'Team Pyramid',
+        description: INSPECT_DESCRIPTION,
+        assetKey: '',
+        previewKind: 'pyramid',
+        linkUrl: TEAM_PYRAMID_VIDEO_URL,
+        linkLabel: 'The Power of the Pyramid (YouTube)',
+        secondaryLinkUrl: TEAM_PYRAMID_VIDEO_URL_ALT,
+        secondaryLinkLabel: 'Launch of the Pyramid (YouTube)',
+      });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const now = Date.now();
+  const buffActive = expiresAt != null && Number.isFinite(expiresAt) && now < expiresAt;
+
+  useFrame((state) => {
+    const g = groupRef.current;
+    if (!g) return;
+
+    const exp = useGameStore.getState().teamPyramidBuffExpiresAt;
+    if (exp != null && Date.now() >= exp) {
+      setTeamPyramidBuffExpiresAt(null);
+      if (useGameStore.getState().nearThrowableId === TEAM_PYRAMID_INSPECT_ID) {
+        setNearThrowable(null);
+      }
+      return;
+    }
+    if (exp == null) return;
+
+    const t = state.clock.elapsedTime;
+    g.position.x = TEAM_PYRAMID_WORLD_POSITION[0];
+    g.position.z = TEAM_PYRAMID_WORLD_POSITION[2];
+    g.position.y = TEAM_PYRAMID_WORLD_POSITION[1] + Math.sin(t * 1.2) * 0.12;
+    // Upright tablet: spin around world Y so the triangle face stays vertical.
+    g.rotation.y = t * 0.65;
+
+    const player = state.scene.getObjectByName('localPlayer');
+    if (!player) return;
+    g.getWorldPosition(worldPos.current);
+    const px = player.position.x;
+    const pz = player.position.z;
+    const dx = px - worldPos.current.x;
+    const dz = pz - worldPos.current.z;
+    const dist = Math.sqrt(dx * dx + dz * dz);
+    const near = dist < TEAM_PYRAMID_INSPECT_RADIUS;
+    const gs = useGameStore.getState();
+    if (near && (gs.nearThrowableId === null || gs.nearThrowableId === TEAM_PYRAMID_INSPECT_ID)) {
+      if (gs.nearThrowableId !== TEAM_PYRAMID_INSPECT_ID) {
+        setNearThrowable(TEAM_PYRAMID_INSPECT_ID);
+      }
+    } else if (!near && gs.nearThrowableId === TEAM_PYRAMID_INSPECT_ID) {
+      setNearThrowable(null);
+    }
+  });
+
+  if (!buffActive) return null;
+
+  const showPrompt = nearThrowableId === TEAM_PYRAMID_INSPECT_ID;
+
+  return (
+    <group
+      ref={groupRef}
+      position={[
+        TEAM_PYRAMID_WORLD_POSITION[0],
+        TEAM_PYRAMID_WORLD_POSITION[1],
+        TEAM_PYRAMID_WORLD_POSITION[2],
+      ]}
+    >
+      <group scale={2.05}>
+        <TeamPyramidTabletMesh />
+      </group>
+      {showPrompt && (
+        <Billboard position={[0, 1.15, 0]}>
+          <Text
+            fontSize={0.16}
+            color="#d8b4fe"
+            anchorX="center"
+            anchorY="middle"
+            outlineWidth={0.012}
+            outlineColor="black"
+            onSync={onOverlayTextSync}
+          >
+            [F] Inspect
+          </Text>
+        </Billboard>
+      )}
+    </group>
+  );
+}

--- a/src/components/world/working-area/TeamPyramidTabletMesh.tsx
+++ b/src/components/world/working-area/TeamPyramidTabletMesh.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import { createSabreScreenTexture } from './sabreScreenTexture';
+
+/**
+ * Stylized equilateral “tablet” (Sabre Pyramid–style): white bezel, dark base + textured “glass” UI.
+ * Shared by the world prop and the inspect overlay preview.
+ */
+export function TeamPyramidTabletMesh() {
+  const screenTexture = useMemo(() => createSabreScreenTexture(), []);
+  useEffect(() => {
+    return () => {
+      screenTexture.dispose();
+    };
+  }, [screenTexture]);
+
+  const { bezelGeometry, screenGeometry, displayPlaneSize, zScreenPlus, zScreenMinus, zGlassPlus, zGlassMinus } =
+    useMemo(() => {
+    const shape = new THREE.Shape();
+    // Triangle in XY plane (vertical in world); extrusion is along Z for thin depth.
+    const w = 0.62;
+    const h = 0.68;
+    shape.moveTo(0, h * 0.52);
+    shape.lineTo(-w * 0.5, -h * 0.48);
+    shape.lineTo(w * 0.5, -h * 0.48);
+    shape.closePath();
+
+    const extrudeSettings: THREE.ExtrudeGeometryOptions = {
+      depth: 0.09,
+      bevelEnabled: true,
+      bevelThickness: 0.022,
+      bevelSize: 0.024,
+      bevelSegments: 2,
+      curveSegments: 12,
+    };
+
+    const bezelGeometry = new THREE.ExtrudeGeometry(shape, extrudeSettings);
+    bezelGeometry.center();
+    bezelGeometry.computeBoundingBox();
+    const bb = bezelGeometry.boundingBox;
+    // Bevel extends past nominal depth — fixed Z offsets sit *inside* the solid; use bbox + epsilon.
+    const pad = 0.004;
+    const zScreenPlus = (bb?.max.z ?? 0.06) + pad;
+    const zScreenMinus = (bb?.min.z ?? -0.06) - pad;
+    const zGlassPlus = (bb?.max.z ?? 0.06) - 0.002;
+    const zGlassMinus = (bb?.min.z ?? -0.06) + 0.002;
+
+    // Inner face: same triangle as the bezel, scaled down slightly (was ~38% — too small).
+    const INNER_SCALE = 0.92;
+    const iw = w * INNER_SCALE;
+    const ih = h * INNER_SCALE;
+    const innerTri = new THREE.Shape();
+    innerTri.moveTo(0, ih * 0.52);
+    innerTri.lineTo(-iw * 0.5, -ih * 0.48);
+    innerTri.lineTo(iw * 0.5, -ih * 0.48);
+    innerTri.closePath();
+    const screenGeo = new THREE.ShapeGeometry(innerTri);
+    // Bounding box of that triangle (matches plane for canvas UVs).
+    const dispW = iw;
+    const dispH = ih;
+    return {
+      bezelGeometry,
+      screenGeometry: screenGeo,
+      displayPlaneSize: [dispW, dispH] as const,
+      zScreenPlus,
+      zScreenMinus,
+      zGlassPlus,
+      zGlassMinus,
+    };
+  }, []);
+
+  return (
+    <group>
+      <mesh geometry={bezelGeometry} castShadow receiveShadow>
+        <meshStandardMaterial color="#e8e8ec" metalness={0.25} roughness={0.45} />
+      </mesh>
+      {/* Dark glass — flush with each cap (inside the bezel). */}
+      <mesh geometry={screenGeometry} position={[0, 0, zGlassPlus]}>
+        <meshStandardMaterial
+          color="#0f172a"
+          emissive="#3b0764"
+          emissiveIntensity={0.35}
+          metalness={0.15}
+          roughness={0.4}
+        />
+      </mesh>
+      <mesh geometry={screenGeometry} position={[0, 0, zGlassMinus]} rotation={[0, Math.PI, 0]}>
+        <meshStandardMaterial
+          color="#0f172a"
+          emissive="#3b0764"
+          emissiveIntensity={0.35}
+          metalness={0.15}
+          roughness={0.4}
+        />
+      </mesh>
+
+      {/*
+        Canvas UI — placed *outside* the extruded bbox so it is never buried in the gray shell.
+      */}
+      <mesh position={[0, 0, zScreenPlus]} renderOrder={3} frustumCulled={false}>
+        <planeGeometry args={[displayPlaneSize[0], displayPlaneSize[1]]} />
+        <meshBasicMaterial
+          map={screenTexture}
+          color="#ffffff"
+          transparent
+          opacity={1}
+          alphaTest={0.02}
+          side={THREE.DoubleSide}
+          depthWrite
+          depthTest
+          polygonOffset
+          polygonOffsetFactor={-4}
+          polygonOffsetUnits={-4}
+          toneMapped={false}
+        />
+      </mesh>
+      <mesh position={[0, 0, zScreenMinus]} rotation={[0, Math.PI, 0]} renderOrder={3} frustumCulled={false}>
+        <planeGeometry args={[displayPlaneSize[0], displayPlaneSize[1]]} />
+        <meshBasicMaterial
+          map={screenTexture}
+          color="#ffffff"
+          transparent
+          opacity={1}
+          alphaTest={0.02}
+          side={THREE.DoubleSide}
+          depthWrite
+          depthTest
+          polygonOffset
+          polygonOffsetFactor={-4}
+          polygonOffsetUnits={-4}
+          toneMapped={false}
+        />
+      </mesh>
+    </group>
+  );
+}

--- a/src/components/world/working-area/sabreScreenTexture.ts
+++ b/src/components/world/working-area/sabreScreenTexture.ts
@@ -1,0 +1,84 @@
+import * as THREE from 'three';
+
+/**
+ * Lightweight “Sabre Pyramid” style UI: purple/blue glow, triangular icons, bottom dock.
+ * Drawn once to a canvas for use on the tablet face (keeps GPU simple).
+ */
+export function createSabreScreenTexture(): THREE.CanvasTexture {
+  const canvas = document.createElement('canvas');
+  canvas.width = 512;
+  canvas.height = 512;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    const fallback = new THREE.CanvasTexture(canvas);
+    fallback.colorSpace = THREE.SRGBColorSpace;
+    return fallback;
+  }
+
+  ctx.clearRect(0, 0, 512, 512);
+
+  // Clip to triangle (upright tablet face)
+  ctx.beginPath();
+  ctx.moveTo(256, 40);
+  ctx.lineTo(52, 472);
+  ctx.lineTo(460, 472);
+  ctx.closePath();
+  ctx.clip();
+
+  const bg = ctx.createRadialGradient(200, 160, 10, 256, 300, 360);
+  bg.addColorStop(0, '#93c5fd');
+  bg.addColorStop(0.25, '#6366f1');
+  bg.addColorStop(0.5, '#4f46e5');
+  bg.addColorStop(0.75, '#312e81');
+  bg.addColorStop(1, '#172554');
+  ctx.fillStyle = bg;
+  ctx.fillRect(0, 0, 512, 512);
+
+  // Soft light streaks
+  ctx.strokeStyle = 'rgba(255,255,255,0.1)';
+  ctx.lineWidth = 1.5;
+  for (let i = 0; i < 14; i++) {
+    ctx.beginPath();
+    ctx.moveTo(-20, i * 38);
+    ctx.lineTo(520, i * 38 + 100);
+    ctx.stroke();
+  }
+
+  const drawTri = (cx: number, cy: number, r: number, a: string) => {
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - r);
+    ctx.lineTo(cx - r * 0.88, cy + r * 0.52);
+    ctx.lineTo(cx + r * 0.88, cy + r * 0.52);
+    ctx.closePath();
+    ctx.fillStyle = a;
+    ctx.fill();
+  };
+
+  // Loose “pyramid of apps” (reference layout, simplified)
+  drawTri(256, 165, 32, 'rgba(255,255,255,0.55)');
+  drawTri(200, 235, 24, 'rgba(255,255,255,0.42)');
+  drawTri(312, 235, 24, 'rgba(255,255,255,0.42)');
+  drawTri(256, 275, 22, 'rgba(255,255,255,0.38)');
+  drawTri(175, 315, 18, 'rgba(255,255,255,0.32)');
+  drawTri(337, 315, 18, 'rgba(255,255,255,0.32)');
+  drawTri(256, 345, 18, 'rgba(255,255,255,0.28)');
+
+  // Bottom dock bar
+  ctx.fillStyle = 'rgba(30, 64, 175, 0.55)';
+  ctx.fillRect(72, 418, 368, 44);
+  ctx.strokeStyle = 'rgba(147, 197, 253, 0.35)';
+  ctx.lineWidth = 1;
+  ctx.strokeRect(72, 418, 368, 44);
+
+  const dockY = 438;
+  [130, 200, 270, 340].forEach((x) => {
+    drawTri(x, dockY, 12, 'rgba(186, 230, 253, 0.95)');
+  });
+
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  tex.premultiplyAlpha = false;
+  tex.needsUpdate = true;
+  tex.anisotropy = 8;
+  return tex;
+}

--- a/src/gameConfig.ts
+++ b/src/gameConfig.ts
@@ -105,3 +105,16 @@ export const ICE_CREAM_COST_REAMS = 2;
 
 /** Duration of the ice cream prop in milliseconds. */
 export const ICE_CREAM_DURATION_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Vending machine — Team Pyramid (room buff)
+// ---------------------------------------------------------------------------
+
+/** Paper reams required to purchase the Team Pyramid room buff. */
+export const TEAM_PYRAMID_COST_REAMS = 80;
+
+/** How long the Team Pyramid buff lasts after purchase (milliseconds). */
+export const TEAM_PYRAMID_DURATION_MS = 3 * 60 * 60 * 1000;
+
+/** Multiplier applied to focus-session ream earn rate while the buff is active. */
+export const TEAM_PYRAMID_FOCUS_REAM_MULTIPLIER = 1.5;

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -224,6 +224,23 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       }
     });
 
+    const applyTeamPyramidBuff = (payload: { expiresAt?: unknown }) => {
+      const raw = payload?.expiresAt;
+      if (raw == null) {
+        useGameStore.getState().setTeamPyramidBuffExpiresAt(null);
+        return;
+      }
+      const n = typeof raw === 'number' ? raw : Number(raw);
+      if (!Number.isFinite(n) || Date.now() >= n) {
+        useGameStore.getState().setTeamPyramidBuffExpiresAt(null);
+        return;
+      }
+      useGameStore.getState().setTeamPyramidBuffExpiresAt(n);
+    };
+
+    newSocket.on('teamPyramidBuffLoaded', applyTeamPyramidBuff);
+    newSocket.on('teamPyramidBuffUpdated', applyTeamPyramidBuff);
+
     newSocket.on('roomInfoLoaded', (info: RoomInfo) => {
       console.log(`[socket] roomInfoLoaded: role=${info.myRole ?? 'visitor'} members=${info.memberCount}`);
       useGameStore.getState().setRoomInfo(info);
@@ -306,6 +323,7 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       useGameStore.getState().clearWornProp();
       useGameStore.getState().setNearWaterCooler(false);
       useGameStore.getState().setWaterBuffExpiresAt(null);
+      useGameStore.getState().setTeamPyramidBuffExpiresAt(null);
       newSocket.disconnect();
     };
   }, [user, currentRoom]);

--- a/src/officeLayout.ts
+++ b/src/officeLayout.ts
@@ -11,6 +11,25 @@ export const WORKING_AREA_BOUNDS = {
   z2: 23,
 } as const;
 
+/** Horizontal center of the working area (world X and Z). */
+export const WORKING_AREA_CENTER_XZ: [number, number] = [
+  (WORKING_AREA_BOUNDS.x1 + WORKING_AREA_BOUNDS.x2) / 2,
+  (WORKING_AREA_BOUNDS.z1 + WORKING_AREA_BOUNDS.z2) / 2,
+];
+
+/**
+ * Floating Team Pyramid prop position (working-area center, elevated).
+ * Y is meters above the floor.
+ */
+export const TEAM_PYRAMID_WORLD_POSITION: [number, number, number] = [
+  WORKING_AREA_CENTER_XZ[0],
+  4.85,
+  WORKING_AREA_CENTER_XZ[1],
+];
+
+/** Proximity radius for inspecting the floating Team Pyramid (meters). */
+export const TEAM_PYRAMID_INSPECT_RADIUS = 3;
+
 /** Minimum distance from working-area walls before placing a desk. */
 export const DESK_SPAWN_MARGIN = 3;
 

--- a/src/propIds.ts
+++ b/src/propIds.ts
@@ -1,6 +1,9 @@
 /** ThrowableObject id for the Regional Manager office “Michael Suit” (ms_body.glb). */
 export const MS_BODY_THROWABLE_ID = 'ms_body';
 
+/** Inspect-only floating prop when Team Pyramid room buff is active (not throwable). */
+export const TEAM_PYRAMID_INSPECT_ID = 'team_pyramid';
+
 export function isWearableThrowableId(id: string): boolean {
   return id === MS_BODY_THROWABLE_ID;
 }

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -9,9 +9,27 @@ import {
 } from '../focusEnergyModel';
 import { CHAIR_UPGRADE_MAX_LEVEL } from '../chairUpgradeConstants';
 import { MONITOR_UPGRADE_MAX_LEVEL, focusReamsPerMinute } from '../monitorUpgradeConstants';
-import { POMODORO_FOCUS_DURATION_SEC, POMODORO_BREAK_DURATION_SEC } from '../gameConfig';
+import {
+  POMODORO_FOCUS_DURATION_SEC,
+  POMODORO_BREAK_DURATION_SEC,
+  TEAM_PYRAMID_FOCUS_REAM_MULTIPLIER,
+} from '../gameConfig';
 import { getEffectiveDeskUpgradeEmail } from '../deskOwner';
 import { AvatarConfig, DEFAULT_AVATAR_CONFIG, FurnitureItem, RoomInfo } from '../types';
+
+export type InspectPreviewKind = 'model' | 'pyramid';
+
+export type InspectedObjectData = {
+  id: string;
+  label: string;
+  description: string;
+  assetKey: string;
+  linkUrl?: string;
+  linkLabel?: string;
+  secondaryLinkUrl?: string;
+  secondaryLinkLabel?: string;
+  previewKind?: InspectPreviewKind;
+};
 
 interface GameState {
   // Throwable object system
@@ -25,8 +43,8 @@ interface GameState {
   droppingObjectId: string | null;
 
   // Inspect mode
-  inspectedObject: { id: string; label: string; description: string; assetKey: string } | null;
-  openInspect: (data: { id: string; label: string; description: string; assetKey: string }) => void;
+  inspectedObject: InspectedObjectData | null;
+  openInspect: (data: InspectedObjectData) => void;
   closeInspect: () => void;
 
   // Paper Clicker State
@@ -110,6 +128,10 @@ interface GameState {
   /** Local-only: epoch ms when water cooler buff ends (extra focus regen while window overlaps wall-clock ticks). */
   waterBuffExpiresAt: number | null;
   setWaterBuffExpiresAt: (expiresAt: number | null) => void;
+
+  /** Server-synced: epoch ms when room Team Pyramid buff ends (null = inactive). */
+  teamPyramidBuffExpiresAt: number | null;
+  setTeamPyramidBuffExpiresAt: (expiresAt: number | null) => void;
   showLeaderboard: boolean;
   setShowLeaderboard: (show: boolean) => void;
 
@@ -162,7 +184,11 @@ export const useGameStore = create<GameState>((set, get) => ({
   dropObject: () => set((s) => ({ heldObjectId: null, droppingObjectId: s.heldObjectId })),
 
   inspectedObject: null,
-  openInspect: (data) => set({ inspectedObject: data, nearThrowableId: null }),
+  openInspect: (data) =>
+    set({
+      inspectedObject: { previewKind: 'model', ...data },
+      nearThrowableId: null,
+    }),
   closeInspect: () => set({ inspectedObject: null }),
 
   paperReams: 0,
@@ -263,7 +289,15 @@ export const useGameStore = create<GameState>((set, get) => ({
       );
       const basePerMin = focusReamsPerMinute(monitorLv);
       const mult = focusReamMultiplier(state.focusEnergy);
-      const reamsPerMin = basePerMin * mult;
+      let reamsPerMin = basePerMin * mult;
+      const pyramidExp = state.teamPyramidBuffExpiresAt;
+      if (
+        typeof pyramidExp === 'number' &&
+        Number.isFinite(pyramidExp) &&
+        Date.now() < pyramidExp
+      ) {
+        reamsPerMin *= TEAM_PYRAMID_FOCUS_REAM_MULTIPLIER;
+      }
       const lastT = state.lastFocusPaperTickAt > 0 ? state.lastFocusPaperTickAt : now;
       const dtSec = Math.min(120, Math.max(0, (now - lastT) / 1000));
       const addFloat = (reamsPerMin / 60) * dtSec;
@@ -411,6 +445,9 @@ export const useGameStore = create<GameState>((set, get) => ({
   setNearWaterCooler: (near) => set({ nearWaterCooler: near }),
   waterBuffExpiresAt: null,
   setWaterBuffExpiresAt: (expiresAt) => set({ waterBuffExpiresAt: expiresAt }),
+
+  teamPyramidBuffExpiresAt: null,
+  setTeamPyramidBuffExpiresAt: (expiresAt) => set({ teamPyramidBuffExpiresAt: expiresAt }),
   showLeaderboard: false,
   setShowLeaderboard: (show) => set({ showLeaderboard: show }),
 


### PR DESCRIPTION
## Summary
Adds the **Team Pyramid** vending purchase (80 reams): **3-hour room-wide +50% focus ream** production, server-authoritative payment, and Socket sync.

## UI / world
- Vend-O-Matic: new purchase row; Pomodoro shows **Power of The Pyramid** and tagline while buff is active.
- Floating **inspect-only** triangular tablet above working-area center; **[F]** opens inspect with description + YouTube links.
- **Sabre-style** canvas screen (purple/blue UI) on both faces of the tablet; inner triangle scaled to ~92% of bezel.

## Technical
- \purchaseTeamPyramid\ + \	eamPyramidBuffLoaded\ / \	eamPyramidBuffUpdated\; in-memory per-room expiry.
- \useGameStore\ buff + tick multiplier; \LocalPlayer\ skips pickup for inspect id.
- Optional \gameStore\ unit test for buff multiplier.

## Notes
Buff state is **in-memory** (lost on server restart).

Made with [Cursor](https://cursor.com)