### PR TITLE
Fix remote focused player seat alignment for joiners

### DIFF
--- a/src/__tests__/unit/otherPlayerFocusSeat.test.tsx
+++ b/src/__tests__/unit/otherPlayerFocusSeat.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import type { Player, DeskItem } from '../../types';
+import { getFocusedDeskTransform } from '../../components/player/OtherPlayer';
+
+describe('getFocusedDeskTransform', () => {
+  const basePlayer: Player = {
+    id: 'p1',
+    name: 'Alice',
+    color: '#fff',
+    position: [10, 0, 10],
+    rotation: [0, 0.2, 0],
+    isFocused: true,
+    focusProgress: 0.5,
+    activeDeskId: 'desk-a',
+  };
+
+  it('anchors focused player to active desk chair transform', () => {
+    const desk: DeskItem = {
+      id: 'desk-a',
+      type: 'desk',
+      position: [2, 0, 4],
+      rotation: [0, Math.PI / 2, 0],
+      config: { ownerEmail: 'a@local.test', ownerName: 'Alice' },
+    };
+    const transform = getFocusedDeskTransform(basePlayer, [desk]);
+    expect(transform).not.toBeNull();
+
+    const props = transform!;
+    // Chair offset is [0,0,0.8] rotated by desk yaw (pi/2) => [0.8,0,0]
+    expect(props.position?.[0]).toBeCloseTo(2.8, 4);
+    expect(props.position?.[1]).toBeCloseTo(0, 4);
+    expect(props.position?.[2]).toBeCloseTo(4, 4);
+    expect(props.rotation?.[1]).toBeCloseTo(Math.PI / 2 + Math.PI, 4);
+  });
+
+  it('returns null when focused desk is missing', () => {
+    expect(getFocusedDeskTransform(basePlayer, [])).toBeNull();
+  });
+
+  it('returns null when player is not focused', () => {
+    expect(getFocusedDeskTransform({ ...basePlayer, isFocused: false }, [])).toBeNull();
+  });
+});

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -1,19 +1,40 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Billboard, Text } from '@react-three/drei';
 import * as THREE from 'three';
-import { Player, DEFAULT_AVATAR_CONFIG } from '../../types';
+import { Player, DEFAULT_AVATAR_CONFIG, DeskItem } from '../../types';
 import { ROLL_PIVOT_Y } from '../../constants';
 import { MS_BODY_THROWABLE_ID } from '../../propIds';
 import { CharacterAvatar } from './CharacterAvatar';
 import { OtherPlayerHeldThrowable } from './OtherPlayerHeldThrowable';
 import { ChatBubble } from '../ui/ChatBubble';
 import { getSyncedIceCreamState, iceCreamColorForIndex } from '../../iceCreamFlavors';
+import { useGameStore } from '../../store/useGameStore';
 
 export const OtherPlayer = ({ player }: { player: Player }) => {
   const prevPos = useRef(player.position);
   const [isMoving, setIsMoving] = useState(false);
   const [, setIceCreamTick] = useState(0);
+  const roomLayout = useGameStore((state) => state.roomLayout);
+
+  const focusedDeskTransform = useMemo(() => {
+    if (!player.isFocused || !player.activeDeskId) return null;
+    const desk = roomLayout.find(
+      (item): item is DeskItem => item.type === 'desk' && item.id === player.activeDeskId
+    );
+    if (!desk) return null;
+    const chairOffset = new THREE.Vector3(0, 0, 0.8).applyAxisAngle(
+      new THREE.Vector3(0, 1, 0),
+      desk.rotation[1]
+    );
+    const position: [number, number, number] = [
+      desk.position[0] + chairOffset.x,
+      desk.position[1],
+      desk.position[2] + chairOffset.z,
+    ];
+    const rotation: [number, number, number] = [0, desk.rotation[1] + Math.PI, 0];
+    return { position, rotation };
+  }, [player.isFocused, player.activeDeskId, roomLayout]);
 
   const syncedIce = getSyncedIceCreamState(player);
   const iceExp = syncedIce?.expiresAt ?? null;
@@ -31,6 +52,8 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
     !player.heldThrowableId;
 
   const heldIceCreamColor = showHeldIceCream ? iceCreamColorForIndex(syncedIce!.flavorIndex) : null;
+  const renderPosition = focusedDeskTransform?.position ?? player.position;
+  const renderRotation = focusedDeskTransform?.rotation ?? player.rotation;
 
   useFrame(() => {
     const dist = new THREE.Vector3(...player.position).distanceTo(new THREE.Vector3(...prevPos.current));
@@ -39,7 +62,7 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
   });
 
   return (
-    <group position={player.position} rotation={[0, player.rotation[1], 0]}>
+    <group position={renderPosition} rotation={[0, renderRotation[1], 0]}>
       <group position={[0, ROLL_PIVOT_Y, 0]}>
         <group rotation={[player.isRolling ? -Math.PI * 2 * ((player.rollTimer || 0) / 0.5) : 0, 0, 0]}>
           <group position={[0, -ROLL_PIVOT_Y, 0]}>

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -11,30 +11,38 @@ import { ChatBubble } from '../ui/ChatBubble';
 import { getSyncedIceCreamState, iceCreamColorForIndex } from '../../iceCreamFlavors';
 import { useGameStore } from '../../store/useGameStore';
 
+export function getFocusedDeskTransform(
+  player: Player,
+  roomLayout: { type: string; id: string; position: [number, number, number]; rotation: [number, number, number] }[]
+): { position: [number, number, number]; rotation: [number, number, number] } | null {
+  if (!player.isFocused || !player.activeDeskId) return null;
+  const desk = roomLayout.find(
+    (item): item is DeskItem => item.type === 'desk' && item.id === player.activeDeskId
+  );
+  if (!desk) return null;
+  const chairOffset = new THREE.Vector3(0, 0, 0.8).applyAxisAngle(
+    new THREE.Vector3(0, 1, 0),
+    desk.rotation[1]
+  );
+  const position: [number, number, number] = [
+    desk.position[0] + chairOffset.x,
+    desk.position[1],
+    desk.position[2] + chairOffset.z,
+  ];
+  const rotation: [number, number, number] = [0, desk.rotation[1] + Math.PI, 0];
+  return { position, rotation };
+}
+
 export const OtherPlayer = ({ player }: { player: Player }) => {
   const prevPos = useRef(player.position);
   const [isMoving, setIsMoving] = useState(false);
   const [, setIceCreamTick] = useState(0);
   const roomLayout = useGameStore((state) => state.roomLayout);
 
-  const focusedDeskTransform = useMemo(() => {
-    if (!player.isFocused || !player.activeDeskId) return null;
-    const desk = roomLayout.find(
-      (item): item is DeskItem => item.type === 'desk' && item.id === player.activeDeskId
-    );
-    if (!desk) return null;
-    const chairOffset = new THREE.Vector3(0, 0, 0.8).applyAxisAngle(
-      new THREE.Vector3(0, 1, 0),
-      desk.rotation[1]
-    );
-    const position: [number, number, number] = [
-      desk.position[0] + chairOffset.x,
-      desk.position[1],
-      desk.position[2] + chairOffset.z,
-    ];
-    const rotation: [number, number, number] = [0, desk.rotation[1] + Math.PI, 0];
-    return { position, rotation };
-  }, [player.isFocused, player.activeDeskId, roomLayout]);
+  const focusedDeskTransform = useMemo(
+    () => getFocusedDeskTransform(player, roomLayout),
+    [player, roomLayout]
+  );
 
   const syncedIce = getSyncedIceCreamState(player);
   const iceExp = syncedIce?.expiresAt ?? null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix remote focused avatar placement by deriving render transform from the focused player's `activeDeskId` desk transform.
- Keep fallback behavior to replicated network position/rotation when desk data is unavailable.
- Add focused unit tests for the seat-transform calculation.

## Testing
- `npm run test -- src/__tests__/unit/otherPlayerFocusSeat.test.tsx`
- `npm run lint`
- `npm run build`

## Manual verification note
- Tried to verify via LOCAL_TEST browser sessions, but focus interaction prompt did not appear in this environment, so end-to-end GUI repro is currently blocked.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44fe93b3-afa3-4cff-8e11-8880907cea98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44fe93b3-afa3-4cff-8e11-8880907cea98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

