### PR TITLE
Extend Team Pyramid purchases and broadcast system chat notice

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1176,12 +1176,23 @@ const rooms: Record<string, Record<string, any>> = {};
 
 /** Per-room Team Pyramid buff expiry (epoch ms). In-memory only. */
 const roomTeamPyramidBuffExpiresAt: Record<string, number> = {};
+const TEAM_PYRAMID_SYSTEM_CHAT_TEXT = "Unleash the power of Pyramid!";
 
 function activeTeamPyramidBuffExpiresAt(roomId: string): number | null {
   const raw = roomTeamPyramidBuffExpiresAt[roomId];
   if (typeof raw !== "number" || !Number.isFinite(raw)) return null;
   if (Date.now() >= raw) return null;
   return raw;
+}
+
+function systemChatMessage(text: string) {
+  return {
+    id: `system-${nanoid(10)}`,
+    playerId: "system",
+    playerName: "System",
+    text,
+    time: Date.now(),
+  };
 }
 
 const OFFICE_COLORS = [
@@ -1465,10 +1476,12 @@ io.on("connection", (socket) => {
             respond(result);
             return;
           }
-          const expiresAt = Date.now() + TEAM_PYRAMID_DURATION_MS;
+          const extensionBase = activeTeamPyramidBuffExpiresAt(playerRoom) ?? Date.now();
+          const expiresAt = extensionBase + TEAM_PYRAMID_DURATION_MS;
           roomTeamPyramidBuffExpiresAt[playerRoom] = expiresAt;
           socket.emit("paperReamsLoaded", result.paperReams);
           io.to(playerRoom).emit("teamPyramidBuffUpdated", { expiresAt });
+          io.to(playerRoom).emit("chatMessage", systemChatMessage(TEAM_PYRAMID_SYSTEM_CHAT_TEXT));
           respond({
             ok: true,
             paperReams: result.paperReams,

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -15,6 +15,7 @@ import request from 'supertest';
 import { io as ioc, type Socket } from 'socket.io-client';
 import type { AddressInfo } from 'net';
 import type pg from 'pg';
+import { TEAM_PYRAMID_DURATION_MS } from '../../gameConfig.js';
 
 // Static import so that dotenv.config() in server.ts runs exactly once (at
 // file load time), before any test manipulates process.env. Dynamic
@@ -252,6 +253,23 @@ function waitFor<T = unknown>(socket: Socket, event: string, timeout = 3000): Pr
   });
 }
 
+function emitWithAck<T = unknown>(
+  socket: Socket,
+  event: string,
+  timeout = 3000
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for ack from "${event}"`)),
+      timeout
+    );
+    socket.emit(event, (payload: T) => {
+      clearTimeout(timer);
+      resolve(payload);
+    });
+  });
+}
+
 /**
  * Returns a pool whose query responses are tailored to a successful joinRoom
  * flow: ensureRoom (insert), getRoomMembers (empty → caller becomes admin),
@@ -438,6 +456,86 @@ describe('Socket.IO — chatMessage', () => {
     expect(msg.playerName).toBeTruthy();
     expect(msg.id).toBeTruthy();
     expect(typeof msg.time).toBe('number');
+  });
+});
+
+describe('Socket.IO — purchaseTeamPyramid', () => {
+  let httpServer: any;
+  let buyer: Socket;
+  let watcher: Socket;
+  let port: number;
+
+  const roomId = 'pyramid-room';
+  const buyerEmail = 'pyramid-buyer@example.com';
+  const watcherEmail = 'pyramid-watcher@example.com';
+
+  const connectAs = (email: string) =>
+    ioc(`http://localhost:${port}`, {
+      reconnection: false,
+      extraHeaders: {
+        'x-goog-authenticated-user-email': `accounts.google.com:${email}`,
+      },
+    });
+
+  beforeEach(async () => {
+    vi.stubEnv('LOCAL_TEST', '1');
+    delete process.env.DEV_USER_EMAIL;
+    ({ httpServer } = await createApp());
+    await new Promise<void>(resolve => httpServer.listen(0, resolve));
+    port = (httpServer.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    buyer?.disconnect();
+    watcher?.disconnect();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    vi.unstubAllEnvs();
+    delete process.env.DEV_USER_EMAIL;
+  });
+
+  it('extends an already-active Team Pyramid buff by another full duration', async () => {
+    buyer = connectAs(buyerEmail);
+    await waitFor(buyer, 'connect');
+    buyer.emit('joinRoom', { roomId });
+    await waitFor(buyer, 'currentPlayers');
+
+    const first = await emitWithAck<{ ok: boolean; expiresAt?: number }>(buyer, 'purchaseTeamPyramid');
+    const second = await emitWithAck<{ ok: boolean; expiresAt?: number }>(buyer, 'purchaseTeamPyramid');
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    expect(typeof first.expiresAt).toBe('number');
+    expect(typeof second.expiresAt).toBe('number');
+    expect((second.expiresAt as number) - (first.expiresAt as number)).toBe(TEAM_PYRAMID_DURATION_MS);
+  });
+
+  it('broadcasts the pyramid system message to chat for everyone in the room', async () => {
+    buyer = connectAs(buyerEmail);
+    await waitFor(buyer, 'connect');
+    buyer.emit('joinRoom', { roomId });
+    await waitFor(buyer, 'currentPlayers');
+
+    watcher = connectAs(watcherEmail);
+    await waitFor(watcher, 'connect');
+    watcher.emit('joinRoom', { roomId });
+    await waitFor(watcher, 'currentPlayers');
+
+    const buyerMessagePromise = waitFor<any>(buyer, 'chatMessage');
+    const watcherMessagePromise = waitFor<any>(watcher, 'chatMessage');
+    const purchase = await emitWithAck<{ ok: boolean }>(buyer, 'purchaseTeamPyramid');
+
+    expect(purchase.ok).toBe(true);
+    const [buyerMsg, watcherMsg] = await Promise.all([buyerMessagePromise, watcherMessagePromise]);
+    expect(buyerMsg).toMatchObject({
+      playerId: 'system',
+      playerName: 'System',
+      text: 'Unleash the power of Pyramid!',
+    });
+    expect(watcherMsg).toMatchObject({
+      playerId: 'system',
+      playerName: 'System',
+      text: 'Unleash the power of Pyramid!',
+    });
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- make Team Pyramid purchases stack by extending the current active room buff by another full 3-hour duration, instead of resetting from current time
- broadcast a room-wide system chat message (`Unleash the power of Pyramid!`) whenever a Team Pyramid purchase succeeds
- add Socket.IO integration coverage for both duration extension behavior and room-wide system chat broadcast

## Testing
- `npm run lint`
- `npm run test -- src/__tests__/integration/server.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-022e5e66-9a8f-46b8-99e8-9b6f125adba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-022e5e66-9a8f-46b8-99e8-9b6f125adba8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

