### PR TITLE
Add identity-theft system chat when using others' desk

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1177,6 +1177,8 @@ const rooms: Record<string, Record<string, any>> = {};
 /** Per-room Team Pyramid buff expiry (epoch ms). In-memory only. */
 const roomTeamPyramidBuffExpiresAt: Record<string, number> = {};
 const TEAM_PYRAMID_SYSTEM_CHAT_TEXT = "Unleash the power of Pyramid!";
+const IDENTITY_THEFT_VIDEO_URL = "https://www.youtube.com/watch?v=WaaANll8h18";
+const IDENTITY_THEFT_SYSTEM_CHAT_TEXT = `Identity theft is not a joke! ${IDENTITY_THEFT_VIDEO_URL}`;
 
 function activeTeamPyramidBuffExpiresAt(roomId: string): number | null {
   const raw = roomTeamPyramidBuffExpiresAt[roomId];
@@ -1193,6 +1195,14 @@ function systemChatMessage(text: string) {
     text,
     time: Date.now(),
   };
+}
+
+function deskOwnerEmailByDeskId(layout: FurnitureItem[], deskId: string | null): string | null {
+  if (!deskId) return null;
+  const desk = layout.find((f): f is DeskItem => f.type === "desk" && f.id === deskId);
+  const ownerEmail = desk?.config?.ownerEmail;
+  if (typeof ownerEmail !== "string" || ownerEmail.length === 0) return null;
+  return ownerEmail;
 }
 
 const OFFICE_COLORS = [
@@ -1660,15 +1670,45 @@ io.on("connection", (socket) => {
       }
 
       if (playerRoom && rooms[playerRoom][socket.id]) {
-        rooms[playerRoom][socket.id].isFocused = data.isFocused;
-        rooms[playerRoom][socket.id].focusProgress = data.focusProgress;
-        rooms[playerRoom][socket.id].activeDeskId = data.activeDeskId;
-        if (data.isFocused && typeof data.focusSitPoseIndex === "number") {
-          rooms[playerRoom][socket.id].focusSitPoseIndex = data.focusSitPoseIndex;
-        } else {
-          delete rooms[playerRoom][socket.id].focusSitPoseIndex;
+        const player = rooms[playerRoom][socket.id];
+        const wasFocused = !!player.isFocused;
+        const prevDeskId =
+          typeof player.activeDeskId === "string" ? player.activeDeskId : null;
+        const nextFocused = !!data.isFocused;
+        const nextDeskId =
+          typeof data.activeDeskId === "string" ? data.activeDeskId : null;
+        const startedOrSwitchedDesk =
+          nextFocused && !!nextDeskId && (!wasFocused || prevDeskId !== nextDeskId);
+
+        if (startedOrSwitchedDesk) {
+          void getRoomLayout(playerRoom)
+            .then((layout) => {
+              const deskOwnerEmail = deskOwnerEmailByDeskId(layout, nextDeskId);
+              const sittingPlayerEmail = typeof player.email === "string" ? player.email : user.email;
+              if (
+                deskOwnerEmail &&
+                deskOwnerEmail.toLowerCase() !== sittingPlayerEmail.toLowerCase()
+              ) {
+                io.to(playerRoom).emit(
+                  "chatMessage",
+                  systemChatMessage(IDENTITY_THEFT_SYSTEM_CHAT_TEXT)
+                );
+              }
+            })
+            .catch((err) => {
+              console.error("playerFocusUpdate identity-theft warning failed:", err);
+            });
         }
-        socket.to(playerRoom).emit("playerMoved", rooms[playerRoom][socket.id]);
+
+        player.isFocused = data.isFocused;
+        player.focusProgress = data.focusProgress;
+        player.activeDeskId = data.activeDeskId;
+        if (data.isFocused && typeof data.focusSitPoseIndex === "number") {
+          player.focusSitPoseIndex = data.focusSitPoseIndex;
+        } else {
+          delete player.focusSitPoseIndex;
+        }
+        socket.to(playerRoom).emit("playerMoved", player);
       }
     });
 

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -459,6 +459,85 @@ describe('Socket.IO — chatMessage', () => {
   });
 });
 
+describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
+  let httpServer: any;
+  let owner: Socket;
+  let intruder: Socket;
+  let port: number;
+  const roomId = 'identity-theft-room';
+  const ownerEmail = 'desk-owner@example.com';
+  const intruderEmail = 'desk-intruder@example.com';
+  const expectedText =
+    'Identity theft is not a joke! https://www.youtube.com/watch?v=WaaANll8h18';
+
+  const connectAs = (email: string) =>
+    ioc(`http://localhost:${port}`, {
+      reconnection: false,
+      extraHeaders: {
+        'x-goog-authenticated-user-email': `accounts.google.com:${email}`,
+      },
+    });
+
+  beforeEach(async () => {
+    vi.stubEnv('LOCAL_TEST', '1');
+    delete process.env.DEV_USER_EMAIL;
+    ({ httpServer } = await createApp());
+    await new Promise<void>(resolve => httpServer.listen(0, resolve));
+    port = (httpServer.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    owner?.disconnect();
+    intruder?.disconnect();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    vi.unstubAllEnvs();
+    delete process.env.DEV_USER_EMAIL;
+  });
+
+  it('broadcasts a system warning when a player focuses at another player desk', async () => {
+    owner = connectAs(ownerEmail);
+    await waitFor(owner, 'connect');
+    owner.emit('joinRoom', { roomId });
+    await waitFor(owner, 'currentPlayers');
+    await waitFor<any[]>(owner, 'roomLayoutLoaded');
+
+    intruder = connectAs(intruderEmail);
+    await waitFor(intruder, 'connect');
+    intruder.emit('joinRoom', { roomId });
+    await waitFor(intruder, 'currentPlayers');
+    const intruderLayout = await waitFor<any[]>(intruder, 'roomLayoutLoaded');
+
+    const ownerDesk = intruderLayout.find(
+      (f: any) => f.type === 'desk' && f.config?.ownerEmail === ownerEmail
+    );
+    expect(ownerDesk).toBeDefined();
+
+    const ownerMessagePromise = waitFor<any>(owner, 'chatMessage');
+    const intruderMessagePromise = waitFor<any>(intruder, 'chatMessage');
+    intruder.emit('playerFocusUpdate', {
+      isFocused: true,
+      focusProgress: 0.1,
+      activeDeskId: ownerDesk.id,
+      focusSitPoseIndex: 0,
+    });
+
+    const [ownerMsg, intruderMsg] = await Promise.all([
+      ownerMessagePromise,
+      intruderMessagePromise,
+    ]);
+    expect(ownerMsg).toMatchObject({
+      playerId: 'system',
+      playerName: 'System',
+      text: expectedText,
+    });
+    expect(intruderMsg).toMatchObject({
+      playerId: 'system',
+      playerName: 'System',
+      text: expectedText,
+    });
+  });
+});
+
 describe('Socket.IO — purchaseTeamPyramid', () => {
   let httpServer: any;
   let buyer: Socket;

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -497,15 +497,17 @@ describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
   it('broadcasts a system warning when a player focuses at another player desk', async () => {
     owner = connectAs(ownerEmail);
     await waitFor(owner, 'connect');
+    const ownerLayoutPromise = waitFor<any[]>(owner, 'roomLayoutLoaded');
     owner.emit('joinRoom', { roomId });
     await waitFor(owner, 'currentPlayers');
-    await waitFor<any[]>(owner, 'roomLayoutLoaded');
+    await ownerLayoutPromise;
 
     intruder = connectAs(intruderEmail);
     await waitFor(intruder, 'connect');
+    const intruderLayoutPromise = waitFor<any[]>(intruder, 'roomLayoutLoaded');
     intruder.emit('joinRoom', { roomId });
     await waitFor(intruder, 'currentPlayers');
-    const intruderLayout = await waitFor<any[]>(intruder, 'roomLayoutLoaded');
+    const intruderLayout = await intruderLayoutPromise;
 
     const ownerDesk = intruderLayout.find(
       (f: any) => f.type === 'desk' && f.config?.ownerEmail === ownerEmail

--- a/src/components/ui/ChatPanel.tsx
+++ b/src/components/ui/ChatPanel.tsx
@@ -4,6 +4,26 @@ import { ChatMessage } from '../../types';
 import { useGameStore } from '../../store/useGameStore';
 
 const EMOTES = ['👋', '😂', '👍', '🔥', '🏢', '🥬'];
+const URL_PART_REGEX = /(https?:\/\/[^\s]+)/g;
+
+function renderChatText(text: string) {
+  return text.split(URL_PART_REGEX).map((part, idx) => {
+    if (!/^https?:\/\/\S+$/i.test(part)) {
+      return <React.Fragment key={`${idx}-${part}`}>{part}</React.Fragment>;
+    }
+    return (
+      <a
+        key={`${idx}-${part}`}
+        href={part}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline decoration-indigo-400/80 hover:text-indigo-300 transition-colors break-all"
+      >
+        {part}
+      </a>
+    );
+  });
+}
 
 interface ChatPanelProps {
   chatHistory: ChatMessage[];
@@ -46,7 +66,7 @@ export const ChatPanel = ({ chatHistory, onSendMessage }: ChatPanelProps) => {
           {chatHistory.map((msg) => (
             <div key={msg.id} className="text-[10px]">
               <span className="text-indigo-400 font-bold">{msg.playerName}: </span>
-              <span className="text-white/80">{msg.text}</span>
+              <span className="text-white/80">{renderChatText(msg.text)}</span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- send a system chat warning when a player starts focus on another player's desk
- include the requested message text and YouTube link in the system chat payload
- render URLs in Chat Log as clickable links so the video can be opened directly
- add an integration test that verifies both players receive the system message
- stabilize the new integration test by registering `roomLayoutLoaded` listeners before emitting `joinRoom`

## Testing
- npm run lint
- npx vitest run src/__tests__/integration/server.test.ts -t "playerFocusUpdate identity-theft system chat"
- attempted manual browser verification in LOCAL_TEST mode; automated integration test provides deterministic proof for cross-user desk ownership trigger
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76f0118b-bf50-407a-b696-f1fdc1968c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76f0118b-bf50-407a-b696-f1fdc1968c27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

