### PR TITLE
Show identity-theft overhead warning above intruder avatar

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1179,6 +1179,8 @@ const roomTeamPyramidBuffExpiresAt: Record<string, number> = {};
 const TEAM_PYRAMID_SYSTEM_CHAT_TEXT = "Unleash the power of Pyramid!";
 const IDENTITY_THEFT_VIDEO_URL = "https://www.youtube.com/watch?v=WaaANll8h18";
 const IDENTITY_THEFT_SYSTEM_CHAT_TEXT = `Identity theft is not a joke! ${IDENTITY_THEFT_VIDEO_URL}`;
+const IDENTITY_THEFT_OVERHEAD_TEXT = "Identity theft is not a joke!";
+const IDENTITY_THEFT_OVERHEAD_DURATION_MS = 10_000;
 
 function activeTeamPyramidBuffExpiresAt(roomId: string): number | null {
   const raw = roomTeamPyramidBuffExpiresAt[roomId];
@@ -1631,6 +1633,7 @@ io.on("connection", (socket) => {
         // Store last message on player for bubbles
         player.lastMessage = messageText;
         player.lastMessageTime = message.time;
+        delete player.lastMessageDurationMs;
 
         io.to(playerRoom).emit("chatMessage", message);
       }
@@ -1689,10 +1692,20 @@ io.on("connection", (socket) => {
                 deskOwnerEmail &&
                 deskOwnerEmail.toLowerCase() !== sittingPlayerEmail.toLowerCase()
               ) {
+                const messageTime = Date.now();
+                player.lastMessage = IDENTITY_THEFT_OVERHEAD_TEXT;
+                player.lastMessageTime = messageTime;
+                player.lastMessageDurationMs = IDENTITY_THEFT_OVERHEAD_DURATION_MS;
                 io.to(playerRoom).emit(
                   "chatMessage",
                   systemChatMessage(IDENTITY_THEFT_SYSTEM_CHAT_TEXT)
                 );
+                io.to(playerRoom).emit("ambientSpeech", {
+                  playerId: socket.id,
+                  text: IDENTITY_THEFT_OVERHEAD_TEXT,
+                  time: messageTime,
+                  durationMs: IDENTITY_THEFT_OVERHEAD_DURATION_MS,
+                });
               }
             })
             .catch((err) => {
@@ -1767,6 +1780,7 @@ io.on("connection", (socket) => {
       if (speaker) {
         speaker.lastMessage = "Gossip Gossip";
         speaker.lastMessageTime = time;
+        delete speaker.lastMessageDurationMs;
       }
       io.to(roomId).emit("ambientSpeech", {
         playerId: speakerId,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -437,6 +437,7 @@ export default function App() {
               socket={socket}
               lastMessage={lastLocalMessage?.text}
               lastMessageTime={lastLocalMessage?.time}
+              lastMessageDurationMs={lastLocalMessage?.durationMs}
               playerName={visibleDisplayName}
               players={players}
             />

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -469,6 +469,8 @@ describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
   const intruderEmail = 'desk-intruder@example.com';
   const expectedText =
     'Identity theft is not a joke! https://www.youtube.com/watch?v=WaaANll8h18';
+  const expectedOverheadText = 'Identity theft is not a joke!';
+  const expectedOverheadDurationMs = 10_000;
 
   const connectAs = (email: string) =>
     ioc(`http://localhost:${port}`, {
@@ -516,6 +518,8 @@ describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
 
     const ownerMessagePromise = waitFor<any>(owner, 'chatMessage');
     const intruderMessagePromise = waitFor<any>(intruder, 'chatMessage');
+    const ownerOverheadPromise = waitFor<any>(owner, 'ambientSpeech');
+    const intruderOverheadPromise = waitFor<any>(intruder, 'ambientSpeech');
     intruder.emit('playerFocusUpdate', {
       isFocused: true,
       focusProgress: 0.1,
@@ -523,9 +527,11 @@ describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
       focusSitPoseIndex: 0,
     });
 
-    const [ownerMsg, intruderMsg] = await Promise.all([
+    const [ownerMsg, intruderMsg, ownerOverhead, intruderOverhead] = await Promise.all([
       ownerMessagePromise,
       intruderMessagePromise,
+      ownerOverheadPromise,
+      intruderOverheadPromise,
     ]);
     expect(ownerMsg).toMatchObject({
       playerId: 'system',
@@ -537,6 +543,18 @@ describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
       playerName: 'System',
       text: expectedText,
     });
+    expect(ownerOverhead).toMatchObject({
+      playerId: intruder.id,
+      text: expectedOverheadText,
+      durationMs: expectedOverheadDurationMs,
+    });
+    expect(intruderOverhead).toMatchObject({
+      playerId: intruder.id,
+      text: expectedOverheadText,
+      durationMs: expectedOverheadDurationMs,
+    });
+    expect(typeof ownerOverhead.time).toBe('number');
+    expect(typeof intruderOverhead.time).toBe('number');
   });
 });
 

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -39,6 +39,7 @@ interface LocalPlayerProps {
   socket: Socket | null;
   lastMessage?: string;
   lastMessageTime?: number;
+  lastMessageDurationMs?: number;
   playerName: string;
   players: Record<string, Player>;
 }
@@ -47,6 +48,7 @@ export const LocalPlayer = ({
   socket,
   lastMessage,
   lastMessageTime,
+  lastMessageDurationMs,
   playerName,
   players,
 }: LocalPlayerProps) => {
@@ -589,7 +591,7 @@ export const LocalPlayer = ({
             )}
           </Billboard>
         )}
-        <ChatBubble text={lastMessage} time={lastMessageTime} />
+        <ChatBubble text={lastMessage} time={lastMessageTime} durationMs={lastMessageDurationMs} />
       </group>
     </>
   );

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -127,7 +127,11 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
           </Text>
         </Billboard>
       )}
-      <ChatBubble text={player.lastMessage} time={player.lastMessageTime} />
+      <ChatBubble
+        text={player.lastMessage}
+        time={player.lastMessageTime}
+        durationMs={player.lastMessageDurationMs}
+      />
     </group>
   );
 };

--- a/src/components/ui/ChatBubble.tsx
+++ b/src/components/ui/ChatBubble.tsx
@@ -2,16 +2,30 @@ import React, { useState, useEffect } from 'react';
 import { Html } from '@react-three/drei';
 import { motion } from 'motion/react';
 
-export const ChatBubble = ({ text, time }: { text?: string, time?: number }) => {
+const DEFAULT_CHAT_BUBBLE_DURATION_MS = 5000;
+
+export const ChatBubble = ({
+  text,
+  time,
+  durationMs,
+}: {
+  text?: string;
+  time?: number;
+  durationMs?: number;
+}) => {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
     if (text && time) {
       setVisible(true);
-      const timer = setTimeout(() => setVisible(false), 5000);
+      const safeDurationMs =
+        typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs > 0
+          ? durationMs
+          : DEFAULT_CHAT_BUBBLE_DURATION_MS;
+      const timer = setTimeout(() => setVisible(false), safeDurationMs);
       return () => clearTimeout(timer);
     }
-  }, [text, time]);
+  }, [text, time, durationMs]);
 
   if (!visible || !text) return null;
 

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -40,7 +40,11 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
     syncRemoteHeldThrowableIds(playerMap);
   };
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
-  const [lastLocalMessage, setLastLocalMessage] = useState<{ text: string; time: number } | null>(null);
+  const [lastLocalMessage, setLastLocalMessage] = useState<{
+    text: string;
+    time: number;
+    durationMs?: number;
+  } | null>(null);
   const [disconnectReason, setDisconnectReason] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
 
@@ -130,18 +134,25 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
               ...prev[message.playerId],
               lastMessage: message.text,
               lastMessageTime: message.time,
+              lastMessageDurationMs: undefined,
             },
           };
         });
       } else {
-        setLastLocalMessage({ text: message.text, time: message.time });
+        setLastLocalMessage({ text: message.text, time: message.time, durationMs: undefined });
       }
     });
 
     newSocket.on(
       'ambientSpeech',
-      (payload: { playerId: string; text: string; time: number }) => {
+      (payload: { playerId: string; text: string; time: number; durationMs?: number }) => {
         if (!payload?.playerId || typeof payload.text !== 'string' || typeof payload.time !== 'number') return;
+        const durationMs =
+          typeof payload.durationMs === 'number' &&
+          Number.isFinite(payload.durationMs) &&
+          payload.durationMs > 0
+            ? payload.durationMs
+            : undefined;
         if (payload.playerId !== newSocket.id) {
           setPlayers((prev) => {
             if (!prev[payload.playerId]) return prev;
@@ -151,11 +162,12 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
                 ...prev[payload.playerId],
                 lastMessage: payload.text,
                 lastMessageTime: payload.time,
+                lastMessageDurationMs: durationMs,
               },
             };
           });
         } else {
-          setLastLocalMessage({ text: payload.text, time: payload.time });
+          setLastLocalMessage({ text: payload.text, time: payload.time, durationMs });
         }
       }
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,8 @@ export interface Player {
   name: string;
   lastMessage?: string;
   lastMessageTime?: number;
+  /** Optional bubble visibility duration in ms for the current overhead message. */
+  lastMessageDurationMs?: number;
   isRolling?: boolean;
   rollTimer?: number;
   isFocused?: boolean;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- When a player starts focus at someone else’s desk, the server now also emits an `ambientSpeech` overhead warning tied to that intruder player (`"Identity theft is not a joke!"`) with a 10s duration.
- Added per-message bubble duration support on the client so identity-theft overhead warnings can stay visible ~10s while normal chat bubbles remain at the default duration.
- Wired the new duration field through socket state for both local and remote players.
- Extended integration coverage to assert that identity-theft overhead warning events are broadcast to everyone in the room with the correct player id, text, and duration.

## Testing
- `npm run test -- src/__tests__/integration/server.test.ts -t "identity-theft"`
- `npm run lint`
- Manual multiplayer verification in local test mode (normal + incognito browser sessions), including visibility and expiration behavior.

## Walkthrough artifacts
[identity_theft_overhead_demo.mp4](https://cursor.com/agents/bc-cddf9cda-3e01-4872-bac4-155785d39a15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentity_theft_overhead_demo.mp4)

[Identity theft overhead bubble visible above intruder avatar](https://cursor.com/agents/bc-cddf9cda-3e01-4872-bac4-155785d39a15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentity_theft_overhead_visible.webp)
[Identity theft overhead bubble disappears after about 10 seconds](https://cursor.com/agents/bc-cddf9cda-3e01-4872-bac4-155785d39a15/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fidentity_theft_overhead_disappeared.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cddf9cda-3e01-4872-bac4-155785d39a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cddf9cda-3e01-4872-bac4-155785d39a15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

