### PR TITLE
feat: focus session saving mode toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -422,52 +422,57 @@ export default function App() {
         <TutorialBanner phase={officeTutorial.phase} onSkip={officeTutorial.skip} />
       )}
 
-      <KeyboardControls map={keyboardMap}>
-        <Canvas
-          shadows={!isFocusSavingModeActive}
-          dpr={isFocusSavingModeActive ? 1 : [1, 2]}
-          frameloop={isFocusSavingModeActive ? 'never' : 'always'}
-          camera={{ position: [0, 2, 5], fov: 50 }}
-        >
-          <color attach="background" args={['#1e293b']} />
-          <ambientLight intensity={0.7} />
-          <directionalLight
-            position={[10, 10, 10]}
-            intensity={1.5}
-            castShadow
-            shadow-mapSize={[1024, 1024]}
-          />
-          <React.Suspense
-            fallback={
-              <Html center>
-                <div className="text-white font-pixel text-[8px] whitespace-nowrap">
-                  LOADING OFFICE...
-                </div>
-              </Html>
-            }
+      {isFocusSavingModeActive ? (
+        <div className="absolute inset-0">
+          <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(56,189,248,0.16),transparent_45%),radial-gradient(circle_at_80%_80%,rgba(99,102,241,0.18),transparent_50%)]" />
+        </div>
+      ) : (
+        <KeyboardControls map={keyboardMap}>
+          <Canvas
+            shadows
+            dpr={[1, 2]}
+            frameloop="always"
+            camera={{ position: [0, 2, 5], fov: 50 }}
           >
-            <OfficeEnvironment />
-            <LocalPlayer
-              socket={socket}
-              lastMessage={lastLocalMessage?.text}
-              lastMessageTime={lastLocalMessage?.time}
-              lastMessageDurationMs={lastLocalMessage?.durationMs}
-              playerName={visibleDisplayName}
-              players={players}
+            <color attach="background" args={['#1e293b']} />
+            <ambientLight intensity={0.7} />
+            <directionalLight
+              position={[10, 10, 10]}
+              intensity={1.5}
+              castShadow
+              shadow-mapSize={[1024, 1024]}
             />
-            {Object.values(players).map((player) => (
-              <OtherPlayer key={player.id} player={player} />
-            ))}
-            <TutorialPathGuide
-              visible={officeTutorial.active}
-              target={officeTutorial.targetPosition}
-            />
-            {!isFocusSavingModeActive && (
+            <React.Suspense
+              fallback={
+                <Html center>
+                  <div className="text-white font-pixel text-[8px] whitespace-nowrap">
+                    LOADING OFFICE...
+                  </div>
+                </Html>
+              }
+            >
+              <OfficeEnvironment />
+              <LocalPlayer
+                socket={socket}
+                lastMessage={lastLocalMessage?.text}
+                lastMessageTime={lastLocalMessage?.time}
+                lastMessageDurationMs={lastLocalMessage?.durationMs}
+                playerName={visibleDisplayName}
+                players={players}
+              />
+              {Object.values(players).map((player) => (
+                <OtherPlayer key={player.id} player={player} />
+              ))}
+              <TutorialPathGuide
+                visible={officeTutorial.active}
+                target={officeTutorial.targetPosition}
+              />
               <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
-            )}
-          </React.Suspense>
-        </Canvas>
-      </KeyboardControls>
+            </React.Suspense>
+          </Canvas>
+        </KeyboardControls>
+      )}
 
       {!isConnected && (
         <div className="absolute inset-0 flex items-center justify-center bg-slate-900 z-50">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ export default function App() {
 
   const {
     isTimerActive,
+    timerMode,
     paperReams,
     avatarConfig,
     setAvatarConfig,
@@ -82,6 +83,7 @@ export default function App() {
     focusEnergy,
     setFocusEnergy,
     tickFocusEnergyWallClock,
+    focusSavingModeEnabled,
   } = useGameStore();
   const [view, setView] = useState<'landing' | 'customize' | 'customize-office'>('landing');
 
@@ -230,6 +232,7 @@ export default function App() {
       : user?.name ?? '';
 
   const officeTutorial = useOfficeTutorial(user?.email, Boolean(currentRoom));
+  const isFocusSavingModeActive = isTimerActive && timerMode === 'focus' && focusSavingModeEnabled;
 
   // ── Loading ──────────────────────────────────────────────────────────────
   if (authLoading) {
@@ -360,17 +363,23 @@ export default function App() {
       </AnimatePresence>
 
       <PomodoroUI />
-      <ParkourEnergyHint />
-      <WaterEnergyBuffOverlay />
-      <PaperBurst />
-      <InspectOverlay />
+      {!isFocusSavingModeActive && (
+        <>
+          <ParkourEnergyHint />
+          <WaterEnergyBuffOverlay />
+          <PaperBurst />
+          <InspectOverlay />
+        </>
+      )}
 
-      <button
-        onClick={() => setShowUI((v) => !v)}
-        className="absolute bottom-6 right-6 z-10 bg-white/10 hover:bg-white/20 backdrop-blur-md border border-white/20 p-3 rounded-full transition-all"
-      >
-        <Info className="text-white w-6 h-6" />
-      </button>
+      {!isFocusSavingModeActive && (
+        <button
+          onClick={() => setShowUI((v) => !v)}
+          className="absolute bottom-6 right-6 z-10 bg-white/10 hover:bg-white/20 backdrop-blur-md border border-white/20 p-3 rounded-full transition-all"
+        >
+          <Info className="text-white w-6 h-6" />
+        </button>
+      )}
 
 
       <AnimatePresence>
@@ -386,35 +395,40 @@ export default function App() {
         )}
       </AnimatePresence>
 
-      {showLeaderboard && currentRoom && (
+      {!isFocusSavingModeActive && showLeaderboard && currentRoom && (
         <div className="absolute top-6 right-[22rem] z-10">
           <RoomLeaderboard roomId={currentRoom} onClose={() => setShowLeaderboard(false)} />
         </div>
       )}
 
-      {showComputerInterface && currentRoom && (
+      {!isFocusSavingModeActive && showComputerInterface && currentRoom && (
         <ComputerInterface
           onClose={() => setShowComputerInterface(false)}
           onOpenAdminPanel={() => { setShowComputerInterface(false); setShowAdminPanel(true); }}
         />
       )}
 
-      {showVendingMenu && currentRoom && (
+      {!isFocusSavingModeActive && showVendingMenu && currentRoom && (
         <VendingMenu socket={socket} onClose={() => setShowVendingMenu(false)} />
       )}
 
-      {showAdminPanel && currentRoom && (roomInfo?.myRole === 'admin' || roomInfo?.myRole === 'manager') && (
+      {!isFocusSavingModeActive && showAdminPanel && currentRoom && (roomInfo?.myRole === 'admin' || roomInfo?.myRole === 'manager') && (
         <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/50">
           <RoomAdminPanel roomId={currentRoom} onClose={() => setShowAdminPanel(false)} />
         </div>
       )}
 
-      {officeTutorial.active && officeTutorial.phase && (
+      {!isFocusSavingModeActive && officeTutorial.active && officeTutorial.phase && (
         <TutorialBanner phase={officeTutorial.phase} onSkip={officeTutorial.skip} />
       )}
 
       <KeyboardControls map={keyboardMap}>
-        <Canvas shadows dpr={[1, 2]} camera={{ position: [0, 2, 5], fov: 50 }}>
+        <Canvas
+          shadows={!isFocusSavingModeActive}
+          dpr={isFocusSavingModeActive ? 1 : [1, 2]}
+          frameloop={isFocusSavingModeActive ? 'never' : 'always'}
+          camera={{ position: [0, 2, 5], fov: 50 }}
+        >
           <color attach="background" args={['#1e293b']} />
           <ambientLight intensity={0.7} />
           <directionalLight
@@ -448,7 +462,9 @@ export default function App() {
               visible={officeTutorial.active}
               target={officeTutorial.targetPosition}
             />
-            <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
+            {!isFocusSavingModeActive && (
+              <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
+            )}
           </React.Suspense>
         </Canvas>
       </KeyboardControls>

--- a/src/__tests__/unit/gameStore.test.ts
+++ b/src/__tests__/unit/gameStore.test.ts
@@ -24,6 +24,7 @@ function resetStore() {
     roomLayout: [],
     user: undefined,
     teamPyramidBuffExpiresAt: null,
+    focusSavingModeEnabled: false,
   });
 }
 
@@ -102,6 +103,30 @@ describe('useGameStore — timer lifecycle', () => {
     useGameStore.getState().togglePause();
     expect(useGameStore.getState().isTimerPaused).toBe(false);
   });
+
+  it('saving mode can only be enabled during active focus sessions', () => {
+    const state = useGameStore.getState();
+    state.setFocusSavingModeEnabled(true);
+    expect(useGameStore.getState().focusSavingModeEnabled).toBe(false);
+
+    state.startTimer('break');
+    state.setFocusSavingModeEnabled(true);
+    expect(useGameStore.getState().focusSavingModeEnabled).toBe(false);
+
+    state.stopTimer();
+    state.startTimer('focus');
+    state.setFocusSavingModeEnabled(true);
+    expect(useGameStore.getState().focusSavingModeEnabled).toBe(true);
+  });
+
+  it('stopTimer always clears saving mode', () => {
+    const state = useGameStore.getState();
+    state.startTimer('focus');
+    state.setFocusSavingModeEnabled(true);
+    expect(useGameStore.getState().focusSavingModeEnabled).toBe(true);
+    state.stopTimer();
+    expect(useGameStore.getState().focusSavingModeEnabled).toBe(false);
+  });
 });
 
 // ── tickTimer ─────────────────────────────────────────────────────────────────
@@ -146,10 +171,12 @@ describe('useGameStore — tickTimer', () => {
 
   it('stops timer when the end time is reached', () => {
     useGameStore.getState().startTimer('focus');
+    useGameStore.getState().setFocusSavingModeEnabled(true);
     vi.advanceTimersByTime(25 * 60 * 1000 + 1000); // past full 25 minutes
     useGameStore.getState().tickTimer();
     expect(useGameStore.getState().isTimerActive).toBe(false);
     expect(useGameStore.getState().activeDeskId).toBeNull();
+    expect(useGameStore.getState().focusSavingModeEnabled).toBe(false);
   });
 
   it('awards paper after 30 seconds of focus (baseline 2 reams/min)', () => {

--- a/src/components/ui/PomodoroUI.tsx
+++ b/src/components/ui/PomodoroUI.tsx
@@ -25,6 +25,8 @@ export const PomodoroUI = () => {
     monitorLevelByEmail,
     focusEnergy,
     teamPyramidBuffExpiresAt,
+    focusSavingModeEnabled,
+    toggleFocusSavingMode,
   } = useGameStore();
   const upgradeEmail = getEffectiveDeskUpgradeEmail(
     roomLayout,
@@ -125,6 +127,29 @@ export const PomodoroUI = () => {
                     </span>
                   </div>
                 )}
+                <div className="mt-2 w-full rounded-xl border border-indigo-400/35 bg-indigo-500/10 px-3 py-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-left">
+                      <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-indigo-200">
+                        Saving Mode
+                      </div>
+                      <div className="text-[10px] leading-snug text-indigo-100/80">
+                        Hide regular UI and reduce render cost.
+                      </div>
+                    </div>
+                    <button
+                      onClick={toggleFocusSavingMode}
+                      className={`px-3 py-1 rounded-full border text-[10px] uppercase tracking-widest font-bold transition-all ${
+                        focusSavingModeEnabled
+                          ? 'border-emerald-400/60 bg-emerald-500/20 text-emerald-200'
+                          : 'border-white/25 bg-white/5 text-slate-300 hover:bg-white/10'
+                      }`}
+                      title="Toggle Saving Mode"
+                    >
+                      {focusSavingModeEnabled ? 'On' : 'Off'}
+                    </button>
+                  </div>
+                </div>
               </div>
             )}
 

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -67,9 +67,13 @@ interface GameState {
   lastFocusPaperTickAt: number;
   /** Random seated leg preset index for the current focus session (set when focus starts). */
   focusSitPoseIndex: number;
+  /** Focus-only low-power UI toggle; auto-disabled outside active focus sessions. */
+  focusSavingModeEnabled: boolean;
   startTimer: (mode: 'focus' | 'break') => void;
   stopTimer: () => void;
   togglePause: () => void;
+  setFocusSavingModeEnabled: (enabled: boolean) => void;
+  toggleFocusSavingMode: () => void;
   tickTimer: () => void;
   resetTimer: () => void;
 
@@ -205,6 +209,7 @@ export const useGameStore = create<GameState>((set, get) => ({
   sessionPaperAccruedFloat: 0,
   lastFocusPaperTickAt: 0,
   focusSitPoseIndex: 0,
+  focusSavingModeEnabled: false,
   startTimer: (mode) =>
     set((state) => {
       const durationSec = mode === 'focus' ? POMODORO_FOCUS_DURATION_SEC : POMODORO_BREAK_DURATION_SEC;
@@ -222,6 +227,7 @@ export const useGameStore = create<GameState>((set, get) => ({
         lastFocusPaperTickAt: mode === 'focus' ? now : 0,
         focusSitPoseIndex:
           mode === 'focus' ? Math.floor(Math.random() * FOCUS_SIT_POSE_COUNT) : state.focusSitPoseIndex,
+        focusSavingModeEnabled: false,
       };
     }),
   stopTimer: () =>
@@ -233,6 +239,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       sessionPaperAccruedFloat: 0,
       lastFocusPaperTickAt: 0,
       focusSitPoseIndex: 0,
+      focusSavingModeEnabled: false,
       timerEndsAt: null,
     }),
   togglePause: () =>
@@ -248,6 +255,16 @@ export const useGameStore = create<GameState>((set, get) => ({
         lastFocusPaperTickAt: Date.now(),
       };
     }),
+  setFocusSavingModeEnabled: (enabled) =>
+    set((state) => {
+      const inFocusSession = state.isTimerActive && state.timerMode === 'focus';
+      return { focusSavingModeEnabled: inFocusSession ? enabled : false };
+    }),
+  toggleFocusSavingMode: () =>
+    set((state) => {
+      const inFocusSession = state.isTimerActive && state.timerMode === 'focus';
+      return { focusSavingModeEnabled: inFocusSession ? !state.focusSavingModeEnabled : false };
+    }),
   tickTimer: () => set((state) => {
     if (state.isTimerPaused || !state.isTimerActive) return {};
 
@@ -261,6 +278,7 @@ export const useGameStore = create<GameState>((set, get) => ({
         timeLeft: 0,
         activeDeskId: null,
         focusSitPoseIndex: 0,
+        focusSavingModeEnabled: false,
         timerEndsAt: null,
         sessionPaperAccruedFloat: 0,
         lastFocusPaperTickAt: 0,
@@ -333,6 +351,7 @@ export const useGameStore = create<GameState>((set, get) => ({
       sessionPaperAccruedFloat: 0,
       lastFocusPaperTickAt: 0,
       focusSitPoseIndex: 0,
+      focusSavingModeEnabled: false,
       timerEndsAt: null,
     })),
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new focus-only `Saving Mode` toggle in `PomodoroUI`
- hide regular overlays and utility panels while saving mode is active so only Focus Session UI remains
- reduce rendering cost in saving mode by disabling stars, shadows, and frame loop (`frameloop="never"`)
- add store behavior/tests to ensure saving mode only works during active focus sessions and auto-resets when focus ends
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b580758b-9003-407c-9c03-e85b86482472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b580758b-9003-407c-9c03-e85b86482472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

