### PR TITLE
Ice cream: eat with B, quarters sync, hint, +4 focus energy per bite

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -29,6 +29,7 @@ import {
   monitorUpgradeCostForNextLevel,
 } from "./src/monitorUpgradeConstants.js";
 import {
+  ICE_CREAM_QUARTERS_MAX,
   TEAM_PYRAMID_COST_REAMS,
   TEAM_PYRAMID_DURATION_MS,
 } from "./src/gameConfig.js";
@@ -1549,7 +1550,9 @@ io.on("connection", (socket) => {
       socket.to(playerRoom).emit("playerMoved", rooms[playerRoom][socket.id]);
     });
 
-    socket.on("playerIceCream", (data: { flavorIndex: number | null; expiresAt: number | null }) => {
+    socket.on(
+      "playerIceCream",
+      (data: { flavorIndex: number | null; expiresAt: number | null; remainingQuarters?: number | null }) => {
       let playerRoom = "";
       for (const roomId in rooms) {
         if (rooms[roomId][socket.id]) {
@@ -1564,6 +1567,7 @@ io.on("connection", (socket) => {
       if (fi == null || ex == null) {
         delete player.iceCreamFlavorIndex;
         delete player.iceCreamExpiresAt;
+        delete player.iceCreamRemainingQuarters;
       } else {
         const fiNum = typeof fi === "number" ? fi : Number(fi);
         const exNum = typeof ex === "number" ? ex : Number(ex);
@@ -1572,11 +1576,17 @@ io.on("connection", (socket) => {
         const now = Date.now();
         // Allow client/server clock skew (±several minutes); duration is ~1 min client-side.
         if (exNum < now - 180_000 || exNum > now + 8 * 60_000) return;
+        const rqRaw = data?.remainingQuarters;
+        let rqNum = rqRaw == null ? ICE_CREAM_QUARTERS_MAX : typeof rqRaw === "number" ? rqRaw : Number(rqRaw);
+        if (!Number.isFinite(rqNum) || rqNum !== Math.floor(rqNum)) rqNum = ICE_CREAM_QUARTERS_MAX;
+        rqNum = Math.min(ICE_CREAM_QUARTERS_MAX, Math.max(1, rqNum));
         player.iceCreamFlavorIndex = fiNum;
         player.iceCreamExpiresAt = exNum;
+        player.iceCreamRemainingQuarters = rqNum;
       }
       socket.to(playerRoom).emit("playerMoved", player);
-    });
+    }
+    );
 
     socket.on("throwableRestSync", (data: { throwableId: string; position: number[]; rotation: number[] }) => {
       let playerRoom = "";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,7 @@ const KEYBOARD_MAP = [
   { name: 'interact', keys: ['KeyE'] },
   { name: 'computer', keys: ['KeyF'] },
   { name: 'drop', keys: ['KeyG'] },
+  { name: 'eatIceCream', keys: ['KeyB'] },
 ];
 
 function getRoomFromURL(): string | null {

--- a/src/components/player/CharacterAvatar.tsx
+++ b/src/components/player/CharacterAvatar.tsx
@@ -3,6 +3,7 @@ import { useFrame } from '@react-three/fiber';
 import { Box } from '@react-three/drei';
 import * as THREE from 'three';
 import { MS_BODY_THROWABLE_ID } from '../../propIds';
+import { ICE_CREAM_QUARTERS_MAX } from '../../gameConfig';
 import { FOCUS_SIT_POSES, FOCUS_SIT_POSE_COUNT } from '../../avatarFocusPoses';
 import { WornMsBody } from './WornMsBody';
 import { HeldIceCream } from './HeldIceCream';
@@ -22,6 +23,7 @@ export const CharacterAvatar = ({
   pantColor = '#333333',
   wornUpperPropId,
   heldIceCreamColor = null,
+  heldIceCreamRemainingQuarters = ICE_CREAM_QUARTERS_MAX,
   isFocused = false,
   focusSitPoseIndex = 0,
 }: {
@@ -35,6 +37,8 @@ export const CharacterAvatar = ({
   wornUpperPropId?: string | null;
   /** When set, a small ice cream is attached to the right hand. */
   heldIceCreamColor?: string | null;
+  /** Scoop size for held ice cream (only used when `heldIceCreamColor` is set). */
+  heldIceCreamRemainingQuarters?: number;
   /** When true, legs use a seated preset instead of standing idle. */
   isFocused?: boolean;
   /** Index into `FOCUS_SIT_POSES` (clamped). */
@@ -195,7 +199,7 @@ export const CharacterAvatar = ({
           <meshStandardMaterial color={skinTone} />
           {heldIceCreamColor ? (
             <group position={[0.1, -0.3, 0.06]} rotation={[0.25, 0, -0.2]}>
-              <HeldIceCream color={heldIceCreamColor} />
+              <HeldIceCream color={heldIceCreamColor} remainingQuarters={heldIceCreamRemainingQuarters} />
             </group>
           ) : null}
         </mesh>

--- a/src/components/player/HeldIceCream.tsx
+++ b/src/components/player/HeldIceCream.tsx
@@ -1,15 +1,28 @@
 import React from 'react';
+import { ICE_CREAM_QUARTERS_MAX } from '../../gameConfig';
 
 /** Tiny cone + scoop for the blocky avatar hand (local units). */
-export function HeldIceCream({ color }: { color: string }) {
+export function HeldIceCream({
+  color,
+  remainingQuarters = ICE_CREAM_QUARTERS_MAX,
+}: {
+  color: string;
+  /** 1–4; scoop height scales by this / max (cone unchanged). */
+  remainingQuarters?: number;
+}) {
+  const q = Math.min(ICE_CREAM_QUARTERS_MAX, Math.max(1, Math.floor(remainingQuarters)));
+  const scoopK = q / ICE_CREAM_QUARTERS_MAX;
+  const scoopR = 0.075;
+  const scoopY = -0.015 + scoopR * scoopK;
+
   return (
     <group scale={1.05}>
       <mesh position={[0, -0.06, 0]} rotation={[Math.PI, 0, 0]}>
         <coneGeometry args={[0.065, 0.16, 10]} />
         <meshStandardMaterial color="#b08968" roughness={0.7} />
       </mesh>
-      <mesh position={[0, 0.06, 0]}>
-        <sphereGeometry args={[0.075, 10, 10]} />
+      <mesh position={[0, scoopY, 0]} scale={[1, scoopK, 1]}>
+        <sphereGeometry args={[scoopR, 10, 10]} />
         <meshStandardMaterial color={color} roughness={0.35} />
       </mesh>
     </group>

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -18,7 +18,11 @@ import {
   PARKOUR_MIN_ENERGY_REQUIRED,
   focusWalkSpeedMultiplier,
 } from '../../focusEnergyModel';
-import { POMODORO_FOCUS_DURATION_SEC } from '../../gameConfig';
+import {
+  ICE_CREAM_BITE_FOCUS_ENERGY,
+  ICE_CREAM_QUARTERS_MAX,
+  POMODORO_FOCUS_DURATION_SEC,
+} from '../../gameConfig';
 import { requestFocusNotificationPermissionIfNeeded } from '../../lib/focusSessionCompleteFeedback';
 import { onOverlayTextSync } from '../../utils/overlayTextSync';
 
@@ -64,6 +68,7 @@ export const LocalPlayer = ({
   const prevInteractRef = useRef(false);
   const prevComputerRef = useRef(false);
   const prevDropRef = useRef(false);
+  const prevEatIceCreamRef = useRef(false);
   const cameraRayRef = useRef(new THREE.Ray());
   const cameraHitRef = useRef(new THREE.Vector3());
 
@@ -163,11 +168,22 @@ export const LocalPlayer = ({
 
     const rawKeys = get();
 
-    const keys =
-      isChatFocused || isTimerActive || isInspecting || showVendingMenu
-        ? { forward: false, backward: false, left: false, right: false, jump: false, interact: false, computer: false, drop: false }
-        : rawKeys;
-    const { forward, backward, left, right, jump, interact, computer, drop } = keys;
+    const blockMovement = isChatFocused || isTimerActive || isInspecting || showVendingMenu;
+    const keys = blockMovement
+      ? {
+          forward: false,
+          backward: false,
+          left: false,
+          right: false,
+          jump: false,
+          interact: false,
+          computer: false,
+          drop: false,
+          eatIceCream:
+            !isChatFocused && !isInspecting && !showVendingMenu ? rawKeys.eatIceCream : false,
+        }
+      : rawKeys;
+    const { forward, backward, left, right, jump, interact, computer, drop, eatIceCream } = keys;
 
     setIsMoving(forward || backward || left || right);
 
@@ -178,6 +194,8 @@ export const LocalPlayer = ({
     prevComputerRef.current = computer;
     const dropEdge = drop && !prevDropRef.current;
     prevDropRef.current = drop;
+    const eatIceCreamEdge = eatIceCream && !prevEatIceCreamRef.current;
+    prevEatIceCreamRef.current = eatIceCream;
 
     // Throwable object interactions take priority over desk interactions
     let interactConsumed = false;
@@ -248,6 +266,33 @@ export const LocalPlayer = ({
           camDir.normalize();
           throwObject([camDir.x * 10, 5, camDir.z * 10]);
           emitHeldThrowableSync(socket, null);
+        }
+      }
+    }
+
+    if (eatIceCreamEdge) {
+      const iceNow = useGameStore.getState().heldIceCream;
+      const objId = useGameStore.getState().heldObjectId;
+      if (
+        iceNow &&
+        Date.now() < iceNow.expiresAt &&
+        objId === null &&
+        iceNow.remainingQuarters >= 1
+      ) {
+        const st = useGameStore.getState();
+        st.setFocusEnergy(st.focusEnergy + ICE_CREAM_BITE_FOCUS_ENERGY);
+        const nextQ = iceNow.remainingQuarters - 1;
+        if (nextQ <= 0) {
+          useGameStore.getState().setHeldIceCream(null);
+          socket?.connected && socket.emit('playerIceCream', { flavorIndex: null, expiresAt: null });
+        } else {
+          useGameStore.getState().setHeldIceCream({ ...iceNow, remainingQuarters: nextQ });
+          socket?.connected &&
+            socket.emit('playerIceCream', {
+              flavorIndex: iceNow.flavorIndex,
+              expiresAt: iceNow.expiresAt,
+              remainingQuarters: nextQ,
+            });
         }
       }
     }
@@ -528,10 +573,12 @@ export const LocalPlayer = ({
                 heldIceCreamColor={
                   heldIceCream &&
                   Date.now() < heldIceCream.expiresAt &&
+                  heldIceCream.remainingQuarters >= 1 &&
                   heldObjectId === null
                     ? iceCreamColorForIndex(heldIceCream.flavorIndex)
                     : null
                 }
+                heldIceCreamRemainingQuarters={heldIceCream?.remainingQuarters ?? ICE_CREAM_QUARTERS_MAX}
                 isFocused={isTimerActive}
                 focusSitPoseIndex={focusSitPoseIndex}
               />
@@ -558,6 +605,27 @@ export const LocalPlayer = ({
             </Text>
           </Billboard>
         )}
+        {heldIceCream &&
+          Date.now() < heldIceCream.expiresAt &&
+          heldIceCream.remainingQuarters >= 1 &&
+          heldObjectId === null &&
+          !isChatFocused &&
+          !isInspecting &&
+          !showVendingMenu && (
+            <Billboard position={[0, 1.42, 0.48]}>
+              <Text
+                fontSize={0.14}
+                color="#fdf4ff"
+                anchorX="center"
+                anchorY="middle"
+                outlineWidth={0.008}
+                outlineColor="black"
+                onSync={onOverlayTextSync}
+              >
+                Press [B] to eat your ice cream
+              </Text>
+            </Billboard>
+          )}
         {isTimerActive && (
           <Billboard position={[0, 3.0, 0]}>
             {/* Outer background */}

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -52,7 +52,7 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
     const ms = iceExp - Date.now() + 30;
     const id = window.setTimeout(() => setIceCreamTick((t) => t + 1), Math.max(ms, 0));
     return () => clearTimeout(id);
-  }, [iceExp, syncedIce?.flavorIndex]);
+  }, [iceExp, syncedIce?.flavorIndex, syncedIce?.remainingQuarters]);
 
   const showHeldIceCream =
     syncedIce != null &&
@@ -84,6 +84,7 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
               pantColor={player.avatarConfig?.pantColor ?? DEFAULT_AVATAR_CONFIG.pantColor}
               wornUpperPropId={player.wornPropId === MS_BODY_THROWABLE_ID ? MS_BODY_THROWABLE_ID : null}
               heldIceCreamColor={heldIceCreamColor}
+              heldIceCreamRemainingQuarters={syncedIce?.remainingQuarters}
               isFocused={player.isFocused ?? false}
               focusSitPoseIndex={player.focusSitPoseIndex ?? 0}
             />

--- a/src/components/ui/HUDPanel.tsx
+++ b/src/components/ui/HUDPanel.tsx
@@ -99,6 +99,7 @@ export const HUDPanel = ({
           ['W x2', 'Roll'],
           ['E', 'Focus'],
           ['F', 'Computer'],
+          ['B', 'Eat ice cream'],
         ].map(([key, label]) => (
           <div key={key} className="flex items-center gap-2 text-white/80 text-[10px]">
             <kbd className="bg-white/20 px-1.5 py-0.5 rounded border border-white/10">{key}</kbd>

--- a/src/components/ui/VendingMenu.tsx
+++ b/src/components/ui/VendingMenu.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft, X } from 'lucide-react';
 import type { Socket } from 'socket.io-client';
 import { useGameStore } from '../../store/useGameStore';
 import { ICE_CREAM_FLAVORS, ICE_CREAM_FLAVOR_COUNT } from '../../iceCreamFlavors';
+import { ICE_CREAM_QUARTERS_MAX } from '../../gameConfig';
 import {
   CHAIR_UPGRADE_COST_REAMS,
   CHAIR_UPGRADE_MAX_LEVEL,
@@ -111,8 +112,13 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
     const flavorIndex = Math.min(Math.max(0, selectedFlavor), ICE_CREAM_FLAVOR_COUNT - 1);
     const expiresAt = Date.now() + ICE_CREAM_DURATION_MS;
     addPaper(-ICE_CREAM_COST_REAMS);
-    setHeldIceCream({ flavorIndex, expiresAt });
-    socket?.connected && socket.emit('playerIceCream', { flavorIndex, expiresAt });
+    setHeldIceCream({ flavorIndex, expiresAt, remainingQuarters: ICE_CREAM_QUARTERS_MAX });
+    socket?.connected &&
+      socket.emit('playerIceCream', {
+        flavorIndex,
+        expiresAt,
+        remainingQuarters: ICE_CREAM_QUARTERS_MAX,
+      });
     onClose();
   };
 

--- a/src/gameConfig.ts
+++ b/src/gameConfig.ts
@@ -106,6 +106,12 @@ export const ICE_CREAM_COST_REAMS = 2;
 /** Duration of the ice cream prop in milliseconds. */
 export const ICE_CREAM_DURATION_MS = 60_000;
 
+/** Bites until the cone is gone (each bite removes one quarter of the scoop). */
+export const ICE_CREAM_QUARTERS_MAX = 4;
+
+/** Focus energy gained per ice cream bite (clamped to {@link FOCUS_ENERGY_MAX}). */
+export const ICE_CREAM_BITE_FOCUS_ENERGY = 4;
+
 // ---------------------------------------------------------------------------
 // Vending machine — Team Pyramid (room buff)
 // ---------------------------------------------------------------------------

--- a/src/iceCreamFlavors.ts
+++ b/src/iceCreamFlavors.ts
@@ -1,4 +1,5 @@
 import type { Player } from './types';
+import { ICE_CREAM_QUARTERS_MAX } from './gameConfig';
 
 /** Five vending flavors — index is synced over the socket for other players. */
 export const ICE_CREAM_FLAVORS = [
@@ -18,8 +19,8 @@ export function iceCreamColorForIndex(index: number): string {
 
 /** Normalize socket payload so other clients always render held ice cream when valid. */
 export function getSyncedIceCreamState(
-  player: Pick<Player, 'iceCreamFlavorIndex' | 'iceCreamExpiresAt'>
-): { flavorIndex: number; expiresAt: number } | null {
+  player: Pick<Player, 'iceCreamFlavorIndex' | 'iceCreamExpiresAt' | 'iceCreamRemainingQuarters'>
+): { flavorIndex: number; expiresAt: number; remainingQuarters: number } | null {
   const exRaw = player.iceCreamExpiresAt;
   const fiRaw = player.iceCreamFlavorIndex;
   if (exRaw == null || fiRaw == null) return null;
@@ -29,5 +30,13 @@ export function getSyncedIceCreamState(
   if (flavorIndex !== Math.floor(flavorIndex) || flavorIndex < 0 || flavorIndex > ICE_CREAM_FLAVOR_COUNT - 1) {
     return null;
   }
-  return { flavorIndex, expiresAt };
+  const rqRaw = player.iceCreamRemainingQuarters;
+  let remainingQuarters =
+    rqRaw == null ? ICE_CREAM_QUARTERS_MAX : typeof rqRaw === 'number' ? rqRaw : Number(rqRaw);
+  if (!Number.isFinite(remainingQuarters) || remainingQuarters !== Math.floor(remainingQuarters)) {
+    remainingQuarters = ICE_CREAM_QUARTERS_MAX;
+  }
+  remainingQuarters = Math.min(ICE_CREAM_QUARTERS_MAX, Math.max(0, remainingQuarters));
+  if (remainingQuarters < 1) return null;
+  return { flavorIndex, expiresAt, remainingQuarters };
 }

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -149,9 +149,9 @@ interface GameState {
   showVendingMenu: boolean;
   setShowVendingMenu: (show: boolean) => void;
 
-  /** Local Vend-O-Matic treat; cleared when `expiresAt` passes (see LocalPlayer). */
-  heldIceCream: { flavorIndex: number; expiresAt: number } | null;
-  setHeldIceCream: (value: { flavorIndex: number; expiresAt: number } | null) => void;
+  /** Local Vend-O-Matic treat; cleared when `expiresAt` passes or quarters reach 0 (see LocalPlayer). */
+  heldIceCream: { flavorIndex: number; expiresAt: number; remainingQuarters: number } | null;
+  setHeldIceCream: (value: { flavorIndex: number; expiresAt: number; remainingQuarters: number } | null) => void;
 
   /** Local-only: throwable prop id currently worn on the avatar (upper body). */
   wornPropId: string | null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,8 @@ export interface Player {
   iceCreamFlavorIndex?: number | null;
   /** Wall-clock ms when the ice cream prop disappears (client + server validated). */
   iceCreamExpiresAt?: number | null;
+  /** Scoop quarters left (1–4); omitted on older clients means full cone. */
+  iceCreamRemainingQuarters?: number | null;
 }
 
 export interface FurnitureItem {


### PR DESCRIPTION
## Summary
Adds an eat interaction for vending-machine ice cream: each press of **B** consumes one quarter of the scoop (four bites finish the cone or it still expires on the existing timer). State syncs to the room via \playerIceCream\ and \iceCreamRemainingQuarters\.

## Details
- **Visual:** \HeldIceCream\ scales the scoop by remaining quarters; cone unchanged.
- **Input:** \KeyB\ mapped in \KeyboardControls\; eating allowed while seated in focus, but not while chat is focused, inspect overlay, or vending menu is open (same conditions as the B key).
- **UX:** Billboard prompt **Press [B] to eat your ice cream** when holding a valid cone; HUD controls list includes B.
- **Gameplay:** Each successful bite adds \ICE_CREAM_BITE_FOCUS_ENERGY\ (4), clamped to max focus energy; existing debounced \saveFocusEnergy\ persists it.

## Server
- Validates \emainingQuarters\ (1–4) alongside flavor and expiry; clears field when ice cream is removed.

Made with [Cursor](https://cursor.com)