### PR TITLE
perf: reduce CPU/network load across server and client

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1174,6 +1174,7 @@ export async function createApp(injectedPool?: pg.Pool) {
 
   // Player state grouped by room
 const rooms: Record<string, Record<string, any>> = {};
+const socketToRoom = new Map<string, string>();
 
 /** Per-room Team Pyramid buff expiry (epoch ms). In-memory only. */
 const roomTeamPyramidBuffExpiresAt: Record<string, number> = {};
@@ -1290,6 +1291,7 @@ io.on("connection", (socket) => {
         wornPropId: null,
         heldThrowableId: null,
       };
+      socketToRoom.set(socket.id, room);
 
       // Remove stale entries for the same email before sending currentPlayers.
       // The old socket's disconnect event fires asynchronously (after DB awaits above),
@@ -1297,6 +1299,7 @@ io.on("connection", (socket) => {
       for (const socketId of Object.keys(rooms[room])) {
         if (rooms[room][socketId].email === user.email && socketId !== socket.id) {
           delete rooms[room][socketId];
+          socketToRoom.delete(socketId);
           socket.to(room).emit("playerDisconnected", socketId);
         }
       }
@@ -1403,13 +1406,7 @@ io.on("connection", (socket) => {
       "purchaseChairUpgrade",
       async (ack: (r: unknown) => void) => {
         const respond = typeof ack === "function" ? ack : () => {};
-        let playerRoom = "";
-        for (const roomId in rooms) {
-          if (rooms[roomId][socket.id]) {
-            playerRoom = roomId;
-            break;
-          }
-        }
+        const playerRoom = socketToRoom.get(socket.id) ?? "";
         if (!playerRoom) {
           respond({ ok: false, error: "not_in_room" });
           return;
@@ -1442,13 +1439,7 @@ io.on("connection", (socket) => {
       "purchaseMonitorUpgrade",
       async (ack: (r: unknown) => void) => {
         const respond = typeof ack === "function" ? ack : () => {};
-        let playerRoom = "";
-        for (const roomId in rooms) {
-          if (rooms[roomId][socket.id]) {
-            playerRoom = roomId;
-            break;
-          }
-        }
+        const playerRoom = socketToRoom.get(socket.id) ?? "";
         if (!playerRoom) {
           respond({ ok: false, error: "not_in_room" });
           return;
@@ -1481,13 +1472,7 @@ io.on("connection", (socket) => {
       "purchaseTeamPyramid",
       async (ack: (r: unknown) => void) => {
         const respond = typeof ack === "function" ? ack : () => {};
-        let playerRoom = "";
-        for (const roomId in rooms) {
-          if (rooms[roomId][socket.id]) {
-            playerRoom = roomId;
-            break;
-          }
-        }
+        const playerRoom = socketToRoom.get(socket.id) ?? "";
         if (!playerRoom) {
           respond({ ok: false, error: "not_in_room" });
           return;
@@ -1518,14 +1503,8 @@ io.on("connection", (socket) => {
     );
 
     socket.on("playerWornProp", (data: { propId: string | null }) => {
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
-      if (!playerRoom || !rooms[playerRoom][socket.id]) return;
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (!playerRoom || !rooms[playerRoom]?.[socket.id]) return;
       const pid = data?.propId ?? null;
       if (pid !== null && pid !== "ms_body") return;
       rooms[playerRoom][socket.id].wornPropId = pid;
@@ -1536,14 +1515,8 @@ io.on("connection", (socket) => {
     });
 
     socket.on("playerHeldThrowable", (data: { propId: string | null }) => {
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
-      if (!playerRoom || !rooms[playerRoom][socket.id]) return;
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (!playerRoom || !rooms[playerRoom]?.[socket.id]) return;
       const propId = data?.propId ?? null;
       if (!isAllowedHeldThrowableId(propId)) return;
       rooms[playerRoom][socket.id].heldThrowableId = propId;
@@ -1553,14 +1526,8 @@ io.on("connection", (socket) => {
     socket.on(
       "playerIceCream",
       (data: { flavorIndex: number | null; expiresAt: number | null; remainingQuarters?: number | null }) => {
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
-      if (!playerRoom || !rooms[playerRoom][socket.id]) return;
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (!playerRoom || !rooms[playerRoom]?.[socket.id]) return;
       const player = rooms[playerRoom][socket.id];
       const fi = data?.flavorIndex;
       const ex = data?.expiresAt;
@@ -1589,13 +1556,7 @@ io.on("connection", (socket) => {
     );
 
     socket.on("throwableRestSync", (data: { throwableId: string; position: number[]; rotation: number[] }) => {
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
       if (!playerRoom) return;
       if (!data || data.throwableId !== "ms_body") return;
       const { position, rotation } = data;
@@ -1611,26 +1572,16 @@ io.on("connection", (socket) => {
       const sanitized: AvatarConfig = { shirtColor, skinTone, pantColor };
       saveAvatarConfig(user.email, sanitized);
       // Update in-memory state and broadcast to room
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) { playerRoom = roomId; break; }
-      }
-      if (playerRoom && rooms[playerRoom][socket.id]) {
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (playerRoom && rooms[playerRoom]?.[socket.id]) {
         rooms[playerRoom][socket.id].avatarConfig = sanitized;
         socket.to(playerRoom).emit("playerMoved", rooms[playerRoom][socket.id]);
       }
     });
 
     socket.on("chatMessage", (messageText: string) => {
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
-
-      if (playerRoom && rooms[playerRoom][socket.id]) {
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (playerRoom && rooms[playerRoom]?.[socket.id]) {
         const player = rooms[playerRoom][socket.id];
         const message = {
           id: Math.random().toString(36).substring(7),
@@ -1650,16 +1601,8 @@ io.on("connection", (socket) => {
     });
 
     socket.on("playerMovement", (movementData) => {
-      // Find which room the player is in
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
-
-      if (playerRoom && rooms[playerRoom][socket.id]) {
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (playerRoom && rooms[playerRoom]?.[socket.id]) {
         rooms[playerRoom][socket.id].position = movementData.position;
         rooms[playerRoom][socket.id].rotation = movementData.rotation;
         rooms[playerRoom][socket.id].isRolling = movementData.isRolling;
@@ -1674,15 +1617,8 @@ io.on("connection", (socket) => {
       activeDeskId: string | null;
       focusSitPoseIndex?: number;
     }) => {
-      let playerRoom = "";
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          playerRoom = roomId;
-          break;
-        }
-      }
-
-      if (playerRoom && rooms[playerRoom][socket.id]) {
+      const playerRoom = socketToRoom.get(socket.id) ?? "";
+      if (playerRoom && rooms[playerRoom]?.[socket.id]) {
         const player = rooms[playerRoom][socket.id];
         const wasFocused = !!player.isFocused;
         const prevDeskId =
@@ -1746,16 +1682,15 @@ io.on("connection", (socket) => {
         activeUsers.delete(user.email);
       }
 
-      for (const roomId in rooms) {
-        if (rooms[roomId][socket.id]) {
-          delete rooms[roomId][socket.id];
-          io.to(roomId).emit("playerDisconnected", socket.id);
-          
-          // Clean up empty rooms
-          if (Object.keys(rooms[roomId]).length === 0) {
-            delete rooms[roomId];
-          }
-          break;
+      const playerRoom = socketToRoom.get(socket.id);
+      if (playerRoom && rooms[playerRoom]?.[socket.id]) {
+        delete rooms[playerRoom][socket.id];
+        socketToRoom.delete(socket.id);
+        io.to(playerRoom).emit("playerDisconnected", socket.id);
+
+        // Clean up empty rooms
+        if (Object.keys(rooms[playerRoom]).length === 0) {
+          delete rooms[playerRoom];
         }
       }
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,35 +57,35 @@ export default function App() {
   const { socket, players, isConnected, chatHistory, lastLocalMessage, disconnectReason, connectionError, sendMessage } =
     useSocket(user, currentRoom);
 
-  const {
-    isTimerActive,
-    timerMode,
-    paperReams,
-    avatarConfig,
-    setAvatarConfig,
-    setPaperReams,
-    roomLayout,
-    setRoomLayout,
-    roomInfo,
-    showLeaderboard,
-    setShowLeaderboard,
-    showAdminPanel,
-    setShowAdminPanel,
-    showComputerInterface,
-    setShowComputerInterface,
-    showVendingMenu,
-    setShowVendingMenu,
-    setHeldIceCream,
-    setUser,
-    playerProfileLoaded,
-    playerProfileDisplayName,
-    playerProfileJobTitle,
-    setPlayerProfileFromServer,
-    focusEnergy,
-    setFocusEnergy,
-    tickFocusEnergyWallClock,
-    focusSavingModeEnabled,
-  } = useGameStore();
+  const isTimerActive = useGameStore((s) => s.isTimerActive);
+  const timerMode = useGameStore((s) => s.timerMode);
+  const paperReams = useGameStore((s) => s.paperReams);
+  const avatarConfig = useGameStore((s) => s.avatarConfig);
+  const roomLayout = useGameStore((s) => s.roomLayout);
+  const roomInfo = useGameStore((s) => s.roomInfo);
+  const showLeaderboard = useGameStore((s) => s.showLeaderboard);
+  const showAdminPanel = useGameStore((s) => s.showAdminPanel);
+  const showComputerInterface = useGameStore((s) => s.showComputerInterface);
+  const showVendingMenu = useGameStore((s) => s.showVendingMenu);
+  const focusEnergy = useGameStore((s) => s.focusEnergy);
+  const focusSavingModeEnabled = useGameStore((s) => s.focusSavingModeEnabled);
+  const playerProfileLoaded = useGameStore((s) => s.playerProfileLoaded);
+  const playerProfileDisplayName = useGameStore((s) => s.playerProfileDisplayName);
+  const playerProfileJobTitle = useGameStore((s) => s.playerProfileJobTitle);
+
+  // Stable setter references — these don't change across renders
+  const setAvatarConfig = useGameStore((s) => s.setAvatarConfig);
+  const setPaperReams = useGameStore((s) => s.setPaperReams);
+  const setRoomLayout = useGameStore((s) => s.setRoomLayout);
+  const setShowLeaderboard = useGameStore((s) => s.setShowLeaderboard);
+  const setShowAdminPanel = useGameStore((s) => s.setShowAdminPanel);
+  const setShowComputerInterface = useGameStore((s) => s.setShowComputerInterface);
+  const setShowVendingMenu = useGameStore((s) => s.setShowVendingMenu);
+  const setHeldIceCream = useGameStore((s) => s.setHeldIceCream);
+  const setUser = useGameStore((s) => s.setUser);
+  const setPlayerProfileFromServer = useGameStore((s) => s.setPlayerProfileFromServer);
+  const setFocusEnergy = useGameStore((s) => s.setFocusEnergy);
+  const tickFocusEnergyWallClock = useGameStore((s) => s.tickFocusEnergyWallClock);
   const [view, setView] = useState<'landing' | 'customize' | 'customize-office'>('landing');
 
   useFocusSessionCompleteFeedback();

--- a/src/components/player/HeldIceCream.tsx
+++ b/src/components/player/HeldIceCream.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import * as THREE from 'three';
 import { ICE_CREAM_QUARTERS_MAX } from '../../gameConfig';
+
+// Pre-allocated geometries shared across all HeldIceCream instances
+const coneGeo = new THREE.ConeGeometry(0.065, 0.16, 10);
+const scoopGeo = new THREE.SphereGeometry(0.075, 10, 10);
+const coneMat = new THREE.MeshStandardMaterial({ color: '#b08968', roughness: 0.7 });
 
 /** Tiny cone + scoop for the blocky avatar hand (local units). */
 export function HeldIceCream({
@@ -17,12 +23,8 @@ export function HeldIceCream({
 
   return (
     <group scale={1.05}>
-      <mesh position={[0, -0.06, 0]} rotation={[Math.PI, 0, 0]}>
-        <coneGeometry args={[0.065, 0.16, 10]} />
-        <meshStandardMaterial color="#b08968" roughness={0.7} />
-      </mesh>
-      <mesh position={[0, scoopY, 0]} scale={[1, scoopK, 1]}>
-        <sphereGeometry args={[scoopR, 10, 10]} />
+      <mesh position={[0, -0.06, 0]} rotation={[Math.PI, 0, 0]} geometry={coneGeo} material={coneMat} />
+      <mesh position={[0, scoopY, 0]} scale={[1, scoopK, 1]} geometry={scoopGeo}>
         <meshStandardMaterial color={color} roughness={0.35} />
       </mesh>
     </group>

--- a/src/components/player/LocalPlayer.tsx
+++ b/src/components/player/LocalPlayer.tsx
@@ -39,6 +39,16 @@ const WALK_MOVE_SPEED = 6;
 const ROLL_MOVE_SPEED = 18;
 const MOVE_SPEED_SCALE = 1;
 
+// Pre-allocated vectors reused every frame to avoid GC pressure
+const _cameraDir = new THREE.Vector3();
+const _cameraSide = new THREE.Vector3();
+const _moveVector = new THREE.Vector3();
+const _cameraTarget = new THREE.Vector3();
+const _chairOffset = new THREE.Vector3();
+const _currentVec = new THREE.Vector3();
+const _targetVec = new THREE.Vector3();
+const _upAxis = new THREE.Vector3(0, 1, 0);
+
 interface LocalPlayerProps {
   socket: Socket | null;
   lastMessage?: string;
@@ -71,6 +81,7 @@ export const LocalPlayer = ({
   const prevEatIceCreamRef = useRef(false);
   const cameraRayRef = useRef(new THREE.Ray());
   const cameraHitRef = useRef(new THREE.Vector3());
+  const lastMovementEmitRef = useRef(0);
 
   const avatarConfig = useGameStore((state) => state.avatarConfig);
   const playerColor = avatarConfig?.shirtColor ?? getDeterministicColor(playerName);
@@ -125,7 +136,8 @@ export const LocalPlayer = ({
       activeDeskId: isTimerActive ? activeDeskId : null,
       focusSitPoseIndex: isTimerActive ? focusSitPoseIndex : undefined,
     });
-  }, [socket, isTimerActive, timeLeft, activeDeskId, focusSitPoseIndex]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [socket, isTimerActive, activeDeskId, focusSitPoseIndex]);
 
   useFrame((state, delta) => {
     // Keep camera below roof
@@ -332,46 +344,48 @@ export const LocalPlayer = ({
     if (isTimerActive && activeDeskId) {
       const desk = roomLayout.find((d) => d.id === activeDeskId);
       if (desk) {
-        const chairOffset = new THREE.Vector3(0, 0, 0.8).applyAxisAngle(
-          new THREE.Vector3(0, 1, 0),
-          desk.rotation[1]
-        );
+        _chairOffset.set(0, 0, 0.8).applyAxisAngle(_upAxis, desk.rotation[1]);
         const targetPos: [number, number, number] = [
-          desk.position[0] + chairOffset.x,
+          desk.position[0] + _chairOffset.x,
           desk.position[1],
-          desk.position[2] + chairOffset.z,
+          desk.position[2] + _chairOffset.z,
         ];
         const targetRot: [number, number, number] = [0, desk.rotation[1] + Math.PI, 0];
 
-        const currentVec = new THREE.Vector3(...positionRef.current);
-        const targetVec = new THREE.Vector3(...targetPos);
-        if (currentVec.distanceTo(targetVec) > 0.01) {
-          const lerped = currentVec.lerp(targetVec, 0.1);
-          const lerpedPos: [number, number, number] = [lerped.x, lerped.y, lerped.z];
+        _currentVec.set(positionRef.current[0], positionRef.current[1], positionRef.current[2]);
+        _targetVec.set(targetPos[0], targetPos[1], targetPos[2]);
+        if (_currentVec.distanceTo(_targetVec) > 0.01) {
+          _currentVec.lerp(_targetVec, 0.1);
+          const lerpedPos: [number, number, number] = [_currentVec.x, _currentVec.y, _currentVec.z];
           positionRef.current = lerpedPos;
           rotationRef.current = targetRot;
           if (playerRef.current) {
             playerRef.current.position.set(...lerpedPos);
             playerRef.current.rotation.set(0, targetRot[1], 0);
           }
-          socket?.connected &&
-            socket.emit('playerMovement', {
-              position: lerpedPos,
-              rotation: targetRot,
-              isRolling: false,
-              rollTimer: 0,
-            });
+          if (socket?.connected) {
+            const now = performance.now();
+            if (now - lastMovementEmitRef.current >= 50) {
+              socket.emit('playerMovement', {
+                position: lerpedPos,
+                rotation: targetRot,
+                isRolling: false,
+                rollTimer: 0,
+              });
+              lastMovementEmitRef.current = now;
+            }
+          }
         }
 
         // Apply camera follow and bounds clamping during focus session
         if (controlsRef.current) {
           const focusPos = positionRef.current;
-          const focusTarget = new THREE.Vector3(
+          _cameraTarget.set(
             Math.max(-BOUNDS, Math.min(BOUNDS, focusPos[0])),
             Math.max(0, Math.min(7.5, focusPos[1] + 1.5)),
             Math.max(-BOUNDS, Math.min(BOUNDS, focusPos[2]))
           );
-          controlsRef.current.target.lerp(focusTarget, 0.08);
+          controlsRef.current.target.lerp(_cameraTarget, 0.08);
           controlsRef.current.update();
 
           const cam = state.camera;
@@ -442,23 +456,20 @@ export const LocalPlayer = ({
     newPosition[1] = physics.applyGravity(newPosition, delta, deskBoxes);
 
     // Camera-relative movement vector
-    const cameraDir = new THREE.Vector3();
-    state.camera.getWorldDirection(cameraDir);
-    cameraDir.y = 0;
-    cameraDir.normalize();
-    const cameraSide = new THREE.Vector3()
-      .crossVectors(new THREE.Vector3(0, 1, 0), cameraDir)
-      .normalize();
+    state.camera.getWorldDirection(_cameraDir);
+    _cameraDir.y = 0;
+    _cameraDir.normalize();
+    _cameraSide.crossVectors(_upAxis, _cameraDir).normalize();
 
-    const moveVector = new THREE.Vector3();
-    if (forward || physics.isRolling.current) moveVector.add(cameraDir);
-    if (backward && !physics.isRolling.current) moveVector.sub(cameraDir);
-    if (left && !physics.isRolling.current) moveVector.add(cameraSide);
-    if (right && !physics.isRolling.current) moveVector.sub(cameraSide);
+    _moveVector.set(0, 0, 0);
+    if (forward || physics.isRolling.current) _moveVector.add(_cameraDir);
+    if (backward && !physics.isRolling.current) _moveVector.sub(_cameraDir);
+    if (left && !physics.isRolling.current) _moveVector.add(_cameraSide);
+    if (right && !physics.isRolling.current) _moveVector.sub(_cameraSide);
 
-    if (moveVector.length() > 0) {
-      newPosition = physics.applyMovement(newPosition, moveVector, speed, players, deskBoxes);
-      newRotation[1] = Math.atan2(moveVector.x, moveVector.z);
+    if (_moveVector.length() > 0) {
+      newPosition = physics.applyMovement(newPosition, _moveVector, speed, players, deskBoxes);
+      newRotation[1] = Math.atan2(_moveVector.x, _moveVector.z);
     }
 
     // Clamp to office bounds
@@ -485,23 +496,28 @@ export const LocalPlayer = ({
           0, 0
         );
       }
-      socket?.connected &&
-        socket.emit('playerMovement', {
-          position: newPosition,
-          rotation: newRotation,
-          isRolling: physics.isRolling.current,
-          rollTimer: physics.rollTimer.current,
-        });
+      if (socket?.connected) {
+        const now = performance.now();
+        if (now - lastMovementEmitRef.current >= 50) {
+          socket.emit('playerMovement', {
+            position: newPosition,
+            rotation: newRotation,
+            isRolling: physics.isRolling.current,
+            rollTimer: physics.rollTimer.current,
+          });
+          lastMovementEmitRef.current = now;
+        }
+      }
     }
 
     // Camera follow
     if (controlsRef.current) {
-      const target = new THREE.Vector3(
+      _cameraTarget.set(
         Math.max(-BOUNDS, Math.min(BOUNDS, newPosition[0])),
         Math.max(0, Math.min(7.5, newPosition[1] + 1.5)),
         Math.max(-BOUNDS, Math.min(BOUNDS, newPosition[2]))
       );
-      controlsRef.current.target.lerp(target, 0.08);
+      controlsRef.current.target.lerp(_cameraTarget, 0.08);
       controlsRef.current.update();
 
       const cam = state.camera;
@@ -629,8 +645,8 @@ export const LocalPlayer = ({
         {isTimerActive && (
           <Billboard position={[0, 3.0, 0]}>
             {/* Outer background */}
-            <mesh position={[0, 0.1, -0.001]}>
-              <planeGeometry args={[1.8, sessionPaper > 0 ? 0.78 : 0.58]} />
+            <mesh position={[0, 0.1, -0.001]} scale={[1.8, sessionPaper > 0 ? 0.78 : 0.58, 1]}>
+              <planeGeometry args={[1, 1]} />
               <meshBasicMaterial color="#0f172a" transparent opacity={0.9} />
             </mesh>
             {/* Label */}
@@ -642,9 +658,12 @@ export const LocalPlayer = ({
               <planeGeometry args={[1.6, 0.22]} />
               <meshBasicMaterial color="#1e293b" />
             </mesh>
-            {/* Bar fill */}
-            <mesh position={[-(1.6 - focusProgress * 1.6) / 2, 0, 0.001]}>
-              <planeGeometry args={[Math.max(0.001, focusProgress * 1.6), 0.18]} />
+            {/* Bar fill — fixed geometry, scaled via scale-x */}
+            <mesh
+              position={[-(1.6 - Math.max(0.001, focusProgress) * 1.6) / 2, 0, 0.001]}
+              scale={[Math.max(0.001, focusProgress), 1, 1]}
+            >
+              <planeGeometry args={[1.6, 0.18]} />
               <meshBasicMaterial color="#22c55e" />
             </mesh>
             {/* Percent label */}

--- a/src/components/player/OtherPlayer.tsx
+++ b/src/components/player/OtherPlayer.tsx
@@ -5,6 +5,10 @@ import * as THREE from 'three';
 import { Player, DEFAULT_AVATAR_CONFIG, DeskItem } from '../../types';
 import { ROLL_PIVOT_Y } from '../../constants';
 import { MS_BODY_THROWABLE_ID } from '../../propIds';
+
+// Pre-allocated vectors reused every frame to avoid GC pressure
+const _otherPos = new THREE.Vector3();
+const _otherPrev = new THREE.Vector3();
 import { CharacterAvatar } from './CharacterAvatar';
 import { OtherPlayerHeldThrowable } from './OtherPlayerHeldThrowable';
 import { ChatBubble } from '../ui/ChatBubble';
@@ -33,7 +37,7 @@ export function getFocusedDeskTransform(
   return { position, rotation };
 }
 
-export const OtherPlayer = ({ player }: { player: Player }) => {
+export const OtherPlayer = React.memo(({ player }: { player: Player }) => {
   const prevPos = useRef(player.position);
   const [isMoving, setIsMoving] = useState(false);
   const [, setIceCreamTick] = useState(0);
@@ -64,7 +68,9 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
   const renderRotation = focusedDeskTransform?.rotation ?? player.rotation;
 
   useFrame(() => {
-    const dist = new THREE.Vector3(...player.position).distanceTo(new THREE.Vector3(...prevPos.current));
+    _otherPos.set(player.position[0], player.position[1], player.position[2]);
+    _otherPrev.set(prevPos.current[0], prevPos.current[1], prevPos.current[2]);
+    const dist = _otherPos.distanceTo(_otherPrev);
     setIsMoving(dist > 0.01);
     prevPos.current = player.position;
   });
@@ -117,9 +123,12 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
             <planeGeometry args={[1.6, 0.22]} />
             <meshBasicMaterial color="#1e293b" />
           </mesh>
-          {/* Bar fill */}
-          <mesh position={[-(1.6 - player.focusProgress * 1.6) / 2, 0, 0.001]}>
-            <planeGeometry args={[Math.max(0.001, player.focusProgress * 1.6), 0.18]} />
+          {/* Bar fill — fixed geometry, scaled via scale-x */}
+          <mesh
+            position={[-(1.6 - Math.max(0.001, player.focusProgress) * 1.6) / 2, 0, 0.001]}
+            scale={[Math.max(0.001, player.focusProgress), 1, 1]}
+          >
+            <planeGeometry args={[1.6, 0.18]} />
             <meshBasicMaterial color="#22c55e" />
           </mesh>
           {/* Percent label */}
@@ -135,4 +144,4 @@ export const OtherPlayer = ({ player }: { player: Player }) => {
       />
     </group>
   );
-};
+});

--- a/src/components/player/OtherPlayerHeldThrowable.tsx
+++ b/src/components/player/OtherPlayerHeldThrowable.tsx
@@ -1,10 +1,11 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import { useGameAsset, type AssetKey } from '../../hooks/useGameAsset';
 import { heldThrowableIdToDisplay, type NetworkHeldThrowableId } from '../../networkThrowables';
 
 function HeldClone({ assetKey, scale }: { assetKey: AssetKey; scale: number }) {
   const { scene } = useGameAsset(assetKey);
-  return <primitive object={scene.clone()} scale={scale} />;
+  const clonedScene = useMemo(() => scene.clone(), [scene]);
+  return <primitive object={clonedScene} scale={scale} />;
 }
 
 /** Renders another player's held throwable at the same offset as local `useThrowable` held phase.

--- a/src/components/player/WaterEnergyAura.tsx
+++ b/src/components/player/WaterEnergyAura.tsx
@@ -7,6 +7,10 @@ import { useGameStore } from '../../store/useGameStore';
 const BLUE = '#38bdf8';
 const BLUE_SOFT = '#7dd3fc';
 
+// Pre-allocated geometries shared across all WaterEnergyAura instances
+const shellGeometry = new THREE.SphereGeometry(0.95, 20, 20);
+const innerGeometry = new THREE.SphereGeometry(0.62, 16, 16);
+
 /**
  * Blue glow on the local avatar while water cooler buff is active (store: waterBuffExpiresAt).
  */
@@ -52,8 +56,7 @@ export const WaterEnergyAura = () => {
         decay={2}
         position={[0, 1.05, 0]}
       />
-      <mesh ref={shellRef} position={[0, 1.02, 0]}>
-        <sphereGeometry args={[0.95, 20, 20]} />
+      <mesh ref={shellRef} position={[0, 1.02, 0]} geometry={shellGeometry}>
         <meshBasicMaterial
           color={BLUE}
           transparent
@@ -63,8 +66,7 @@ export const WaterEnergyAura = () => {
           side={THREE.DoubleSide}
         />
       </mesh>
-      <mesh ref={innerRef} position={[0, 1.02, 0]}>
-        <sphereGeometry args={[0.62, 16, 16]} />
+      <mesh ref={innerRef} position={[0, 1.02, 0]} geometry={innerGeometry}>
         <meshBasicMaterial
           color={BLUE_SOFT}
           transparent

--- a/src/components/ui/PomodoroUI.tsx
+++ b/src/components/ui/PomodoroUI.tsx
@@ -9,25 +9,23 @@ import { useGameStore } from '../../store/useGameStore';
 import { FocusEnergyBar } from './FocusEnergyBar';
 
 export const PomodoroUI = () => {
-  const {
-    isTimerActive,
-    isTimerPaused,
-    timerMode,
-    timeLeft,
-    tickTimer,
-    stopTimer,
-    togglePause,
-    nearestDeskId,
-    activeDeskId,
-    roomLayout,
-    sessionPaper,
-    user,
-    monitorLevelByEmail,
-    focusEnergy,
-    teamPyramidBuffExpiresAt,
-    focusSavingModeEnabled,
-    toggleFocusSavingMode,
-  } = useGameStore();
+  const isTimerActive = useGameStore((s) => s.isTimerActive);
+  const isTimerPaused = useGameStore((s) => s.isTimerPaused);
+  const timerMode = useGameStore((s) => s.timerMode);
+  const timeLeft = useGameStore((s) => s.timeLeft);
+  const tickTimer = useGameStore((s) => s.tickTimer);
+  const stopTimer = useGameStore((s) => s.stopTimer);
+  const togglePause = useGameStore((s) => s.togglePause);
+  const nearestDeskId = useGameStore((s) => s.nearestDeskId);
+  const activeDeskId = useGameStore((s) => s.activeDeskId);
+  const roomLayout = useGameStore((s) => s.roomLayout);
+  const sessionPaper = useGameStore((s) => s.sessionPaper);
+  const user = useGameStore((s) => s.user);
+  const monitorLevelByEmail = useGameStore((s) => s.monitorLevelByEmail);
+  const focusEnergy = useGameStore((s) => s.focusEnergy);
+  const teamPyramidBuffExpiresAt = useGameStore((s) => s.teamPyramidBuffExpiresAt);
+  const focusSavingModeEnabled = useGameStore((s) => s.focusSavingModeEnabled);
+  const toggleFocusSavingMode = useGameStore((s) => s.toggleFocusSavingMode);
   const upgradeEmail = getEffectiveDeskUpgradeEmail(
     roomLayout,
     activeDeskId,

--- a/src/components/world/shared/props/Chair.tsx
+++ b/src/components/world/shared/props/Chair.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo } from 'react';
+import * as THREE from 'three';
 import { Box, Cylinder } from '@react-three/drei';
 import { getChairVisualParams } from '../../../../chairUpgradeStyle';
+
+// Shared materials for chair decorations
+const grassStemMat = new THREE.MeshStandardMaterial({ color: '#2d6b3a', metalness: 0, roughness: 0.9 });
+const grassLeafMat = new THREE.MeshStandardMaterial({ color: '#3d8b4a', metalness: 0, roughness: 0.88 });
 
 export const Chair = ({
   position,
@@ -43,12 +48,8 @@ export const Chair = ({
       const r = 0.28 + (i % 2) * 0.06;
       return (
         <group key={i} position={[Math.sin(a) * r, 0.04, Math.cos(a) * r]}>
-          <Cylinder args={[0.04, 0.05, 0.1, 6]} position={[0, 0.05, 0]}>
-            <meshStandardMaterial color="#2d6b3a" metalness={0} roughness={0.9} />
-          </Cylinder>
-          <Box args={[0.12, 0.02, 0.08]} position={[0.02, 0.02, 0]} rotation={[0, 0.4, 0]}>
-            <meshStandardMaterial color="#3d8b4a" metalness={0} roughness={0.88} />
-          </Box>
+          <Cylinder args={[0.04, 0.05, 0.1, 6]} position={[0, 0.05, 0]} material={grassStemMat} />
+          <Box args={[0.12, 0.02, 0.08]} position={[0.02, 0.02, 0]} rotation={[0, 0.4, 0]} material={grassLeafMat} />
         </group>
       );
     });

--- a/src/components/world/working-area/Desk.tsx
+++ b/src/components/world/working-area/Desk.tsx
@@ -1,24 +1,26 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { Box, Billboard, Text, Cylinder } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { MONITOR_UPGRADE_MAX_LEVEL } from '../../../monitorUpgradeConstants';
 import { useGameStore } from '../../../store/useGameStore';
 import { Chair } from '../shared/props/Chair';
 import { onOverlayTextSync } from '../../../utils/overlayTextSync';
 
+// Shared materials — avoids creating hundreds of duplicate instances
+const monitorBodyMat = new THREE.MeshStandardMaterial({ color: '#111111' });
+const monitorScreenMat = new THREE.MeshStandardMaterial({ color: '#0a1f33', emissive: new THREE.Color('#1a3a5c'), emissiveIntensity: 0.6 });
+const monitorStandMat = new THREE.MeshStandardMaterial({ color: '#222222' });
+const deskLegMat = new THREE.MeshStandardMaterial({ color: '#333333' });
+const deskPaperMat = new THREE.MeshStandardMaterial({ color: '#f5f5f0' });
+const deskMugMat = new THREE.MeshStandardMaterial({ color: '#2c1810' });
+const deskKeyboardMat = new THREE.MeshStandardMaterial({ color: '#1a1a1a' });
+
 function SingleDeskMonitor() {
   return (
     <group>
-      <Box args={[0.65, 0.42, 0.05]} position={[0, 0.21, -0.2]}>
-        <meshStandardMaterial color="#111111" />
-      </Box>
-      <Box args={[0.55, 0.32, 0.01]} position={[0, 0.21, -0.17]}>
-        <meshStandardMaterial color="#0a1f33" emissive="#1a3a5c" emissiveIntensity={0.6} />
-      </Box>
-      <Box args={[0.2, 0.05, 0.2]} position={[0, 0.025, -0.2]}>
-        <meshStandardMaterial color="#222" />
-      </Box>
+      <Box args={[0.65, 0.42, 0.05]} position={[0, 0.21, -0.2]} material={monitorBodyMat} />
+      <Box args={[0.55, 0.32, 0.01]} position={[0, 0.21, -0.17]} material={monitorScreenMat} />
+      <Box args={[0.2, 0.05, 0.2]} position={[0, 0.025, -0.2]} material={monitorStandMat} />
     </group>
   );
 }
@@ -93,6 +95,7 @@ export const Desk = ({
   hasChair = true,
   ownerName,
   ownerEmail,
+  groupRef,
 }: {
   id: string;
   position: [number, number, number];
@@ -100,13 +103,12 @@ export const Desk = ({
   hasChair?: boolean;
   ownerName?: string;
   ownerEmail?: string;
+  groupRef?: React.Ref<THREE.Group>;
 }) => {
-  const setNearestDeskId = useGameStore((state) => state.setNearestDeskId);
   const nearestDeskId = useGameStore((state) => state.nearestDeskId);
   const isTimerActive = useGameStore((state) => state.isTimerActive);
   const occupiedDeskIds = useGameStore((state) => state.occupiedDeskIds);
   const isOccupied = occupiedDeskIds.includes(id);
-  const deskRef = useRef<THREE.Group>(null);
   const userEmail = useGameStore((state) => state.user?.email);
   const myRole = useGameStore((state) => state.roomInfo?.myRole);
   const chairLevelByEmail = useGameStore((state) => state.chairLevelByEmail);
@@ -135,23 +137,10 @@ export const Desk = ({
   const isOwnDesk = !!ownerEmail && ownerEmail === userEmail;
   const isOwnAdminDesk = isOwnDesk && (myRole === 'admin' || myRole === 'manager');
 
-  useFrame((state) => {
-    if (!deskRef.current) return;
-    const player = state.scene.getObjectByName('localPlayer');
-    if (!player) return;
-
-    const distance = player.position.distanceTo(deskRef.current.position);
-    if (distance < 2) {
-      if (nearestDeskId !== id) setNearestDeskId(id);
-    } else if (nearestDeskId === id) {
-      setNearestDeskId(null);
-    }
-  });
-
   const isNearest = nearestDeskId === id;
 
   return (
-    <group ref={deskRef} position={position} rotation={rotation}>
+    <group ref={groupRef} position={position} rotation={rotation}>
       {deskNameplate && (
         <Billboard position={[0, 1.8, 0]}>
           <Text
@@ -197,36 +186,19 @@ export const Desk = ({
       </Box>
 
       {/* Legs */}
-      <Box args={[0.1, 0.95, 0.1]} position={[-0.9, 0.475, -0.4]}>
-        <meshStandardMaterial color="#333" />
-      </Box>
-      <Box args={[0.1, 0.95, 0.1]} position={[0.9, 0.475, -0.4]}>
-        <meshStandardMaterial color="#333" />
-      </Box>
-      <Box args={[0.1, 0.95, 0.1]} position={[-0.9, 0.475, 0.4]}>
-        <meshStandardMaterial color="#333" />
-      </Box>
-      <Box args={[0.1, 0.95, 0.1]} position={[0.9, 0.475, 0.4]}>
-        <meshStandardMaterial color="#333" />
-      </Box>
+      <Box args={[0.1, 0.95, 0.1]} position={[-0.9, 0.475, -0.4]} material={deskLegMat} />
+      <Box args={[0.1, 0.95, 0.1]} position={[0.9, 0.475, -0.4]} material={deskLegMat} />
+      <Box args={[0.1, 0.95, 0.1]} position={[-0.9, 0.475, 0.4]} material={deskLegMat} />
+      <Box args={[0.1, 0.95, 0.1]} position={[0.9, 0.475, 0.4]} material={deskLegMat} />
 
       {/* Paper stack on desk surface */}
-      <Box args={[0.4, 0.02, 0.3]} position={[0.5, 1.01, 0.1]}>
-        <meshStandardMaterial color="#f5f5f0" />
-      </Box>
+      <Box args={[0.4, 0.02, 0.3]} position={[0.5, 1.01, 0.1]} material={deskPaperMat} />
 
       {/* Coffee mug */}
-      <Cylinder
-        args={[0.06, 0.06, 0.12, 8]}
-        position={[-0.55, 1.06, 0.1]}
-      >
-        <meshStandardMaterial color="#2c1810" />
-      </Cylinder>
+      <Cylinder args={[0.06, 0.06, 0.12, 8]} position={[-0.55, 1.06, 0.1]} material={deskMugMat} />
 
       {/* Keyboard strip */}
-      <Box args={[0.5, 0.02, 0.15]} position={[0, 1.01, 0.25]}>
-        <meshStandardMaterial color="#1a1a1a" />
-      </Box>
+      <Box args={[0.5, 0.02, 0.15]} position={[0, 1.01, 0.25]} material={deskKeyboardMat} />
 
       <DeskMonitors count={monitorCount} />
 

--- a/src/components/world/working-area/WorkingArea.tsx
+++ b/src/components/world/working-area/WorkingArea.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
 import { FloorPlanRect } from '../../../types';
 import { useGameStore } from '../../../store/useGameStore';
 import { DeskItem } from '../../../types';
@@ -8,6 +9,8 @@ import { CeilingLights } from './props/CeilingLights';
 import { Plant } from '../shared/props/Plant';
 import { PrinterStation } from './props/PrinterStation';
 import { WORKING_AREA_BOUNDS } from '../../../officeLayout';
+
+const _deskWorldPos = new THREE.Vector3();
 
 // Working area occupies the open floor; bounds are defined in officeLayout.ts
 export const FLOOR_PLAN_RECT: FloorPlanRect = {
@@ -29,6 +32,32 @@ export const WorkingArea = () => {
   const desks = useGameStore((s) => s.roomLayout).filter(
     (f): f is DeskItem => f.type === 'desk'
   );
+  const deskRefsMap = useRef<Map<string, THREE.Group>>(new Map());
+
+  // Single proximity check for all desks instead of per-desk useFrame hooks
+  useFrame((state) => {
+    const player = state.scene.getObjectByName('localPlayer');
+    if (!player) return;
+
+    const store = useGameStore.getState();
+    let closestId: string | null = null;
+    let closestDist = 2; // proximity threshold
+
+    for (const desk of desks) {
+      const ref = deskRefsMap.current.get(desk.id);
+      if (!ref) continue;
+      ref.getWorldPosition(_deskWorldPos);
+      const dist = player.position.distanceTo(_deskWorldPos);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestId = desk.id;
+      }
+    }
+
+    if (store.nearestDeskId !== closestId) {
+      store.setNearestDeskId(closestId);
+    }
+  });
 
   return (
     <group>
@@ -52,6 +81,10 @@ export const WorkingArea = () => {
           rotation={desk.rotation}
           ownerName={String(desk.config.ownerName)}
           ownerEmail={desk.config.ownerEmail}
+          groupRef={(el) => {
+            if (el) deskRefsMap.current.set(desk.id, el);
+            else deskRefsMap.current.delete(desk.id);
+          }}
         />
       ))}
     </group>

--- a/src/components/world/working-area/props/CeilingLights.tsx
+++ b/src/components/world/working-area/props/CeilingLights.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as THREE from 'three';
 import { Box } from '@react-three/drei';
 
 // Grid of fluorescent ceiling light fixtures across the working area
@@ -13,15 +14,17 @@ const LIGHT_POSITIONS: [number, number, number][] = [
   [ 5,  7.9,   0],
 ];
 
+const fixtureMat = new THREE.MeshStandardMaterial({
+  color: '#ffffff',
+  emissive: new THREE.Color('#fffaee'),
+  emissiveIntensity: 0.4,
+});
+
 export const CeilingLights = () => (
   <group>
     {LIGHT_POSITIONS.map(([x, y, z], i) => (
       <group key={i} position={[x, y, z]}>
-        {/* Fixture geometry — thin flat white box */}
-        <Box args={[2, 0.05, 0.4]}>
-          <meshStandardMaterial color="#ffffff" emissive="#fffaee" emissiveIntensity={0.4} />
-        </Box>
-        {/* Warm-white point light pointing downward */}
+        <Box args={[2, 0.05, 0.4]} material={fixtureMat} />
         <pointLight
           color="#fffaee"
           intensity={0.8}

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -11,33 +11,29 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
   const [players, setPlayers] = useState<Record<string, Player>>({});
   const [isConnected, setIsConnected] = useState(false);
 
-  const syncOccupiedDesks = (playerMap: Record<string, Player>) => {
-    const ids = Object.values(playerMap)
+  const syncFromPlayerMap = (playerMap: Record<string, Player>) => {
+    const players = Object.values(playerMap);
+    const occupiedDeskIds = players
       .filter((p) => p.activeDeskId)
       .map((p) => p.activeDeskId as string);
-    useGameStore.getState().setOccupiedDeskIds(ids);
-  };
-
-  const syncRemoteWornThrowableIds = (playerMap: Record<string, Player>) => {
-    const worn: string[] = [];
-    for (const p of Object.values(playerMap)) {
-      if (p.wornPropId) worn.push(p.wornPropId);
+    const remoteWornThrowableIds: string[] = [];
+    const remoteHeldThrowableIds: string[] = [];
+    for (const p of players) {
+      if (p.wornPropId) remoteWornThrowableIds.push(p.wornPropId);
+      if (p.heldThrowableId) remoteHeldThrowableIds.push(p.heldThrowableId);
     }
-    useGameStore.getState().setRemoteWornThrowableIds(worn);
-  };
 
-  const syncRemoteHeldThrowableIds = (playerMap: Record<string, Player>) => {
-    const held: string[] = [];
-    for (const p of Object.values(playerMap)) {
-      if (p.heldThrowableId) held.push(p.heldThrowableId);
+    const state = useGameStore.getState();
+    const arraysEqual = (a: string[], b: string[]) =>
+      a.length === b.length && a.every((v, i) => v === b[i]);
+
+    if (
+      !arraysEqual(occupiedDeskIds, state.occupiedDeskIds) ||
+      !arraysEqual(remoteWornThrowableIds, state.remoteWornThrowableIds) ||
+      !arraysEqual(remoteHeldThrowableIds, state.remoteHeldThrowableIds)
+    ) {
+      useGameStore.setState({ occupiedDeskIds, remoteWornThrowableIds, remoteHeldThrowableIds });
     }
-    useGameStore.getState().setRemoteHeldThrowableIds(held);
-  };
-
-  const syncFromPlayerMap = (playerMap: Record<string, Player>) => {
-    syncOccupiedDesks(playerMap);
-    syncRemoteWornThrowableIds(playerMap);
-    syncRemoteHeldThrowableIds(playerMap);
   };
   const [chatHistory, setChatHistory] = useState<ChatMessage[]>([]);
   const [lastLocalMessage, setLastLocalMessage] = useState<{

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { preloadAllAssets } from './hooks/useGameAsset';
+
+preloadAllAssets();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary

- **Network**: Throttle `playerMovement` from 60fps to 20Hz; remove redundant `playerFocusUpdate` on every timer tick; batch `syncFromPlayerMap` into a single Zustand `setState`; replace O(R) room-scan loops on the server with an O(1) `socketToRoom` Map
- **Re-renders**: Split monolithic `useGameStore()` calls in `App.tsx` and `PomodoroUI.tsx` into individual selectors; wrap `OtherPlayer` in `React.memo`; memoize `scene.clone()` in `OtherPlayerHeldThrowable`
- **Allocations**: Hoist `Vector3` instances out of per-frame callbacks in `LocalPlayer` and `OtherPlayer`; consolidate ~20 per-desk `useFrame` proximity hooks into a single hook in `WorkingArea`
- **Draw calls**: Share materials for desk monitors, legs, ceiling lights, chair grass, water aura spheres, and ice cream cone; share sphere/cone geometries; replace dynamic `planeGeometry` args on focus bars with fixed geometry + scale
- **Assets**: Call `preloadAllAssets()` at startup so GLBs begin loading immediately

## Test plan

- [ ] Join a room and move around — movement should be smooth and responsive
- [ ] Open DevTools Network → WS frames: confirm movement messages are ~20/sec, not 60/sec
- [ ] Start a focus session at a desk — timer, paper accumulation, and progress bar should work correctly
- [ ] Verify other players' names, focus bars, and held items still render correctly
- [ ] Check desk proximity prompt ("Press [E] to Start Focus") appears when walking up to a desk
- [ ] Test chair and monitor upgrades still broadcast to room members
- [ ] Confirm water cooler aura and held ice cream still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)