### PR TITLE
perf: reduce CPU/network load across server and client

### DIFF
--- a/src/__tests__/unit/playerPhysics.test.ts
+++ b/src/__tests__/unit/playerPhysics.test.ts
@@ -25,7 +25,20 @@ vi.mock('three', () => {
     multiplyScalar: vi.fn().mockReturnThis(),
   }));
 
-  return { Box3: MockBox3, Vector3: MockVector3 };
+  const MockMaterial = vi.fn().mockImplementation(() => ({}));
+  const MockGeometry = vi.fn().mockImplementation(() => ({}));
+  return {
+    Box3: MockBox3,
+    Vector3: MockVector3,
+    MeshStandardMaterial: MockMaterial,
+    MeshBasicMaterial: MockMaterial,
+    Color: vi.fn().mockImplementation(() => ({})),
+    SphereGeometry: MockGeometry,
+    ConeGeometry: MockGeometry,
+    Ray: vi.fn().mockImplementation(() => ({})),
+    AdditiveBlending: 2,
+    DoubleSide: 2,
+  };
 });
 
 import { usePlayerPhysics } from '../../hooks/usePlayerPhysics';


### PR DESCRIPTION
## Summary
- **Network throttling**: Throttle `playerMovement` socket emissions from 60fps to 20Hz; replace 3 separate Zustand `set()` calls in `syncFromPlayerMap` with one batched call; replace O(R) room-scan loops on server with O(1) `socketToRoom` map lookup
- **React re-renders**: Split monolithic `useGameStore()` subscriptions in App.tsx and PomodoroUI.tsx into individual selectors; wrap `OtherPlayer` in `React.memo`; memoize `scene.clone()` in `OtherPlayerHeldThrowable`
- **Per-frame allocations**: Hoist all `new THREE.Vector3()` calls in LocalPlayer and OtherPlayer to module-level pre-allocated instances (reused via `.set()`/`.copy()`)
- **Draw calls**: Share geometry/material instances at module level for Desk monitors, Chair grass, CeilingLights, WaterEnergyAura, and HeldIceCream; consolidate per-desk `useFrame` proximity checks into a single loop in WorkingArea
- **Asset preloading**: Call `preloadAllAssets()` at startup in main.tsx
- **Test fix**: Extend `vi.mock('three', ...)` in both unit test files to cover new module-level THREE class instantiations added by this PR

## Test plan
- [ ] All 52 unit tests pass
- [ ] WebSocket message rate drops from ~60/s to ~20/s (DevTools Network → WS)
- [ ] No visual regressions in 3D scene

🤖 Generated with [Claude Code](https://claude.com/claude-code)