### PR TITLE
feat: desk computer as personal hub, desk decorations, team upgrade pool

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -33,6 +33,9 @@ import {
   TEAM_PYRAMID_COST_REAMS,
   TEAM_PYRAMID_DURATION_MS,
 } from "./src/gameConfig.js";
+import { DESK_ITEM_CATALOG } from "./src/deskItemCatalog.js";
+import { TEAM_UPGRADE_DEFS } from "./src/teamUpgradeDefs.js";
+import type { DeskItemPlacement, TeamUpgradePool } from "./src/types.js";
 import { totalPaperReamsEarnedFloor } from "./src/paperReamsLifetime.js";
 import {
   FOCUS_ENERGY_MAX,
@@ -143,6 +146,9 @@ async function initDb() {
   `);
   await pool!.query(`
     ALTER TABLE users ADD COLUMN IF NOT EXISTS focus_energy_desk_owner_email TEXT
+  `);
+  await pool!.query(`
+    ALTER TABLE users ADD COLUMN IF NOT EXISTS desk_items JSONB NOT NULL DEFAULT '[]'
   `);
   await pool!.query(`
     UPDATE users SET focus_energy_updated_at = (EXTRACT(EPOCH FROM NOW()) * 1000)::BIGINT
@@ -500,13 +506,117 @@ async function purchaseMonitorUpgradeTxn(email: string): Promise<MonitorPurchase
   }
 }
 
-type TeamPyramidPurchaseResult =
-  | { ok: true; paperReams: number }
-  | { ok: false; error: "insufficient" };
+// ── Desk Items ──────────────────────────────────────────────────────────────
 
-async function purchaseTeamPyramidTxn(email: string): Promise<TeamPyramidPurchaseResult> {
+async function getDeskItemsForEmails(
+  emails: string[]
+): Promise<Record<string, DeskItemPlacement[]>> {
+  if (emails.length === 0) return {};
   if (isLocalTest()) {
-    return mem.memPurchaseTeamPyramid(email);
+    return mem.memGetDeskItemsForEmails(emails);
+  }
+  const { rows } = await pool!.query(
+    "SELECT email, COALESCE(desk_items, '[]'::jsonb) AS desk_items FROM users WHERE email = ANY($1::text[])",
+    [emails]
+  );
+  const out: Record<string, DeskItemPlacement[]> = {};
+  for (const e of emails) out[e] = [];
+  for (const row of rows) {
+    const items = Array.isArray(row.desk_items) ? row.desk_items : [];
+    out[row.email] = items as DeskItemPlacement[];
+  }
+  return out;
+}
+
+type DeskItemPurchaseResult =
+  | { ok: true; paperReams: number; items: DeskItemPlacement[] }
+  | { ok: false; error: "already_owned" | "insufficient" | "not_found" };
+
+async function purchaseDeskItemTxn(email: string, itemId: string): Promise<DeskItemPurchaseResult> {
+  const def = DESK_ITEM_CATALOG.find((d) => d.id === itemId);
+  if (!def) return { ok: false, error: "not_found" };
+  if (isLocalTest()) {
+    return mem.memPurchaseDeskItem(email, itemId, def.cost);
+  }
+  const client = await pool!.connect();
+  try {
+    await client.query("BEGIN");
+    const sel = await client.query(
+      `SELECT paper_reams,
+              COALESCE(chair_upgrade_level, 0) AS chair_upgrade_level,
+              COALESCE(monitor_upgrade_level, 0) AS monitor_upgrade_level,
+              COALESCE(desk_items, '[]'::jsonb) AS desk_items
+       FROM users WHERE email = $1 FOR UPDATE`,
+      [email]
+    );
+    if (sel.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "insufficient" };
+    }
+    const paper = sel.rows[0].paper_reams as number;
+    const existingItems: DeskItemPlacement[] = Array.isArray(sel.rows[0].desk_items)
+      ? (sel.rows[0].desk_items as DeskItemPlacement[])
+      : [];
+    if (existingItems.some((i) => i.id === itemId)) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "already_owned" };
+    }
+    if (paper < def.cost) {
+      await client.query("ROLLBACK");
+      return { ok: false, error: "insufficient" };
+    }
+    const newPaper = paper - def.cost;
+    // Default position: center of desk surface
+    const newItems: DeskItemPlacement[] = [...existingItems, { id: itemId, x: 0, z: 0 }];
+    const chairLv = Number(sel.rows[0].chair_upgrade_level);
+    const monitorLv = Number(sel.rows[0].monitor_upgrade_level);
+    const floor = totalPaperReamsEarnedFloor(newPaper, chairLv, monitorLv);
+    await client.query(
+      `UPDATE users SET paper_reams = $1, desk_items = $2::jsonb,
+         total_paper_reams_earned = GREATEST(total_paper_reams_earned, $4)
+       WHERE email = $3`,
+      [newPaper, JSON.stringify(newItems), email, floor]
+    );
+    await client.query("COMMIT");
+    return { ok: true, paperReams: newPaper, items: newItems };
+  } catch (err) {
+    try { await client.query("ROLLBACK"); } catch { /* ignore */ }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function saveDeskItemPositionsTxn(
+  email: string,
+  items: DeskItemPlacement[]
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (isLocalTest()) {
+    return mem.memSaveDeskItemPositions(email, items);
+  }
+  // Validate bounds before saving
+  const clamped: DeskItemPlacement[] = items.map((item) => ({
+    id: item.id,
+    x: Math.max(-1, Math.min(1, Number(item.x) || 0)),
+    z: Math.max(-0.4, Math.min(0.4, Number(item.z) || 0)),
+  }));
+  await pool!.query(
+    "UPDATE users SET desk_items = $1::jsonb WHERE email = $2",
+    [JSON.stringify(clamped), email]
+  );
+  return { ok: true };
+}
+
+// ── Team Upgrade Pools ───────────────────────────────────────────────────────
+
+
+/** Deduct reams from a user toward a team upgrade contribution. Pure DB transaction. */
+async function deductReamsForTeamContribution(
+  email: string,
+  amount: number
+): Promise<{ ok: true; paperReams: number } | { ok: false; error: "insufficient" }> {
+  if (isLocalTest()) {
+    return mem.memDeductReamsForTeamContribution(email, amount);
   }
   const client = await pool!.connect();
   try {
@@ -518,16 +628,11 @@ async function purchaseTeamPyramidTxn(email: string): Promise<TeamPyramidPurchas
        FROM users WHERE email = $1 FOR UPDATE`,
       [email]
     );
-    if (sel.rows.length === 0) {
+    if (sel.rows.length === 0 || (sel.rows[0].paper_reams as number) < amount) {
       await client.query("ROLLBACK");
       return { ok: false, error: "insufficient" };
     }
-    const paper = sel.rows[0].paper_reams as number;
-    if (paper < TEAM_PYRAMID_COST_REAMS) {
-      await client.query("ROLLBACK");
-      return { ok: false, error: "insufficient" };
-    }
-    const newPaper = paper - TEAM_PYRAMID_COST_REAMS;
+    const newPaper = (sel.rows[0].paper_reams as number) - amount;
     const chairLv = Number(sel.rows[0].chair_upgrade_level);
     const monitorLv = Number(sel.rows[0].monitor_upgrade_level);
     const floor = totalPaperReamsEarnedFloor(newPaper, chairLv, monitorLv);
@@ -540,11 +645,7 @@ async function purchaseTeamPyramidTxn(email: string): Promise<TeamPyramidPurchas
     await client.query("COMMIT");
     return { ok: true, paperReams: newPaper };
   } catch (err) {
-    try {
-      await client.query("ROLLBACK");
-    } catch {
-      /* ignore */
-    }
+    try { await client.query("ROLLBACK"); } catch { /* ignore */ }
     throw err;
   } finally {
     client.release();
@@ -553,9 +654,13 @@ async function purchaseTeamPyramidTxn(email: string): Promise<TeamPyramidPurchas
 
 async function broadcastDeskChairLevels(io: Server, roomId: string, layout: FurnitureItem[]) {
   const emails = extractDeskOwnerEmails(layout);
-  const { chairs, monitors } = await getChairAndMonitorLevelsForEmails(emails);
+  const [{ chairs, monitors }, deskItemsMap] = await Promise.all([
+    getChairAndMonitorLevelsForEmails(emails),
+    getDeskItemsForEmails(emails),
+  ]);
   io.to(roomId).emit("deskChairLevels", chairs);
   io.to(roomId).emit("deskMonitorLevels", monitors);
+  io.to(roomId).emit("deskItemsLoaded", deskItemsMap);
 }
 
 async function getRoomLayout(roomId: string): Promise<FurnitureItem[]> {
@@ -1176,19 +1281,38 @@ export async function createApp(injectedPool?: pg.Pool) {
 const rooms: Record<string, Record<string, any>> = {};
 const socketToRoom = new Map<string, string>();
 
-/** Per-room Team Pyramid buff expiry (epoch ms). In-memory only. */
-const roomTeamPyramidBuffExpiresAt: Record<string, number> = {};
+/** Per-room team upgrade contribution pools. In-memory only; resets on server restart. */
+const roomTeamUpgradePools: Record<string, Record<string, TeamUpgradePool>> = {};
 const TEAM_PYRAMID_SYSTEM_CHAT_TEXT = "Unleash the power of Pyramid!";
 const IDENTITY_THEFT_VIDEO_URL = "https://www.youtube.com/watch?v=WaaANll8h18";
 const IDENTITY_THEFT_SYSTEM_CHAT_TEXT = `Identity theft is not a joke! ${IDENTITY_THEFT_VIDEO_URL}`;
 const IDENTITY_THEFT_OVERHEAD_TEXT = "Identity theft is not a joke!";
 const IDENTITY_THEFT_OVERHEAD_DURATION_MS = 10_000;
 
+function getOrCreatePool(roomId: string, upgradeType: string): TeamUpgradePool {
+  if (!roomTeamUpgradePools[roomId]) roomTeamUpgradePools[roomId] = {};
+  if (!roomTeamUpgradePools[roomId][upgradeType]) {
+    const def = TEAM_UPGRADE_DEFS[upgradeType];
+    roomTeamUpgradePools[roomId][upgradeType] = {
+      contributed: 0,
+      target: def?.target ?? TEAM_PYRAMID_COST_REAMS,
+      contributors: {},
+      expiresAt: null,
+    };
+  }
+  return roomTeamUpgradePools[roomId][upgradeType];
+}
+
+/** Returns active (not yet expired) pool expiresAt for the pyramid buff; backward-compat helper. */
 function activeTeamPyramidBuffExpiresAt(roomId: string): number | null {
-  const raw = roomTeamPyramidBuffExpiresAt[roomId];
-  if (typeof raw !== "number" || !Number.isFinite(raw)) return null;
-  if (Date.now() >= raw) return null;
-  return raw;
+  const pool = roomTeamUpgradePools[roomId]?.pyramid;
+  if (!pool || pool.expiresAt == null) return null;
+  if (Date.now() >= pool.expiresAt) return null;
+  return pool.expiresAt;
+}
+
+function getRoomTeamUpgradePools(roomId: string): Record<string, TeamUpgradePool> {
+  return roomTeamUpgradePools[roomId] ?? {};
 }
 
 function systemChatMessage(text: string) {
@@ -1307,9 +1431,7 @@ io.on("connection", (socket) => {
       // Send current players in this room to the new player
       socket.emit("currentPlayers", rooms[room]);
 
-      socket.emit("teamPyramidBuffLoaded", {
-        expiresAt: activeTeamPyramidBuffExpiresAt(room),
-      });
+      socket.emit("teamUpgradePoolsLoaded", getRoomTeamUpgradePools(room));
 
       // Broadcast new player to others in the same room
       socket.to(room).emit("newPlayer", rooms[room][socket.id]);
@@ -1352,11 +1474,14 @@ io.on("connection", (socket) => {
         // Visitor: send current layout read-only, no desk created
         getRoomLayout(room).then(async (layout) => {
           socket.emit("roomLayoutLoaded", layout);
-          const { chairs, monitors } = await getChairAndMonitorLevelsForEmails(
-            extractDeskOwnerEmails(layout)
-          );
+          const emails = extractDeskOwnerEmails(layout);
+          const [{ chairs, monitors }, deskItemsMap] = await Promise.all([
+            getChairAndMonitorLevelsForEmails(emails),
+            getDeskItemsForEmails(emails),
+          ]);
           socket.emit("deskChairLevels", chairs);
           socket.emit("deskMonitorLevels", monitors);
+          socket.emit("deskItemsLoaded", deskItemsMap);
         });
       }
 
@@ -1469,9 +1594,16 @@ io.on("connection", (socket) => {
     );
 
     socket.on(
-      "purchaseTeamPyramid",
-      async (ack: (r: unknown) => void) => {
+      "contributeTeamUpgrade",
+      async (payload: { upgradeType?: unknown; amount?: unknown }, ack: (r: unknown) => void) => {
         const respond = typeof ack === "function" ? ack : () => {};
+        const upgradeType = typeof payload?.upgradeType === "string" ? payload.upgradeType : "";
+        const rawAmount = Number(payload?.amount);
+        if (!upgradeType || !(upgradeType in TEAM_UPGRADE_DEFS) || !Number.isFinite(rawAmount) || rawAmount <= 0) {
+          respond({ ok: false, error: "invalid" });
+          return;
+        }
+        const amount = Math.floor(rawAmount);
         const playerRoom = socketToRoom.get(socket.id) ?? "";
         if (!playerRoom) {
           respond({ ok: false, error: "not_in_room" });
@@ -1479,24 +1611,88 @@ io.on("connection", (socket) => {
         }
         try {
           await ensureUserRow(user.email);
-          const result = await purchaseTeamPyramidTxn(user.email);
-          if (!result.ok) {
-            respond(result);
+          const deduct = await deductReamsForTeamContribution(user.email, amount);
+          if (!deduct.ok) {
+            respond(deduct);
             return;
           }
-          const extensionBase = activeTeamPyramidBuffExpiresAt(playerRoom) ?? Date.now();
-          const expiresAt = extensionBase + TEAM_PYRAMID_DURATION_MS;
-          roomTeamPyramidBuffExpiresAt[playerRoom] = expiresAt;
-          socket.emit("paperReamsLoaded", result.paperReams);
-          io.to(playerRoom).emit("teamPyramidBuffUpdated", { expiresAt });
-          io.to(playerRoom).emit("chatMessage", systemChatMessage(TEAM_PYRAMID_SYSTEM_CHAT_TEXT));
-          respond({
-            ok: true,
-            paperReams: result.paperReams,
-            expiresAt,
-          });
+          const pool = getOrCreatePool(playerRoom, upgradeType);
+          // If already active and not expired, re-accumulate for next cycle
+          if (pool.expiresAt != null && Date.now() >= pool.expiresAt) {
+            pool.contributed = 0;
+            pool.contributors = {};
+            pool.expiresAt = null;
+          }
+          pool.contributed += amount;
+          pool.contributors[user.email] = (pool.contributors[user.email] ?? 0) + amount;
+          const def = TEAM_UPGRADE_DEFS[upgradeType];
+          if (pool.contributed >= pool.target && pool.expiresAt == null) {
+            const extensionBase = pool.expiresAt ?? Date.now();
+            pool.expiresAt = extensionBase + def.durationMs;
+            io.to(playerRoom).emit("chatMessage", systemChatMessage(TEAM_PYRAMID_SYSTEM_CHAT_TEXT));
+          }
+          socket.emit("paperReamsLoaded", deduct.paperReams);
+          io.to(playerRoom).emit("teamUpgradePoolUpdated", { upgradeType, pool });
+          respond({ ok: true, paperReams: deduct.paperReams, pool });
         } catch (e) {
-          console.error("purchaseTeamPyramid:", e);
+          console.error("contributeTeamUpgrade:", e);
+          respond({ ok: false, error: "server_error" });
+        }
+      }
+    );
+
+    socket.on(
+      "purchaseDeskItem",
+      async (payload: { itemId?: unknown }, ack: (r: unknown) => void) => {
+        const respond = typeof ack === "function" ? ack : () => {};
+        const itemId = typeof payload?.itemId === "string" ? payload.itemId : "";
+        if (!itemId) { respond({ ok: false, error: "not_found" }); return; }
+        let playerRoom = "";
+        for (const roomId in rooms) {
+          if (rooms[roomId][socket.id]) { playerRoom = roomId; break; }
+        }
+        if (!playerRoom) { respond({ ok: false, error: "not_in_room" }); return; }
+        try {
+          await ensureUserRow(user.email);
+          const result = await purchaseDeskItemTxn(user.email, itemId);
+          if (!result.ok) { respond(result); return; }
+          socket.emit("paperReamsLoaded", result.paperReams);
+          io.to(playerRoom).emit("deskItemUpdated", { email: user.email, items: result.items });
+          respond({ ok: true, paperReams: result.paperReams, items: result.items });
+        } catch (e) {
+          console.error("purchaseDeskItem:", e);
+          respond({ ok: false, error: "server_error" });
+        }
+      }
+    );
+
+    socket.on(
+      "saveDeskItemPositions",
+      async (payload: { items?: unknown }, ack: (r: unknown) => void) => {
+        const respond = typeof ack === "function" ? ack : () => {};
+        const rawItems = payload?.items;
+        if (!Array.isArray(rawItems)) { respond({ ok: false, error: "invalid" }); return; }
+        const items: DeskItemPlacement[] = rawItems
+          .filter((i): i is { id: string; x: number; z: number } =>
+            i && typeof i.id === "string" && typeof i.x === "number" && typeof i.z === "number"
+          )
+          .map((i) => ({
+            id: i.id,
+            x: Math.max(-1, Math.min(1, i.x)),
+            z: Math.max(-0.4, Math.min(0.4, i.z)),
+          }));
+        let playerRoom = "";
+        for (const roomId in rooms) {
+          if (rooms[roomId][socket.id]) { playerRoom = roomId; break; }
+        }
+        try {
+          await saveDeskItemPositionsTxn(user.email, items);
+          if (playerRoom) {
+            io.to(playerRoom).emit("deskItemUpdated", { email: user.email, items });
+          }
+          respond({ ok: true });
+        } catch (e) {
+          console.error("saveDeskItemPositions:", e);
           respond({ ok: false, error: "server_error" });
         }
       }

--- a/server/memoryDb.ts
+++ b/server/memoryDb.ts
@@ -1,7 +1,8 @@
 /** In-memory DB for LOCAL_TEST=1 only. Not used when PostgreSQL is active. */
 
 import { MONITOR_UPGRADE_MAX_LEVEL, monitorUpgradeCostForNextLevel } from "../src/monitorUpgradeConstants.js";
-import { TEAM_PYRAMID_COST_REAMS } from "../src/gameConfig.js";
+import { DESK_ITEM_CATALOG } from "../src/deskItemCatalog.js";
+import type { DeskItemPlacement } from "../src/types.js";
 import { totalPaperReamsEarnedFloor } from "../src/paperReamsLifetime.js";
 import {
   clampFocusEnergy,
@@ -43,6 +44,8 @@ interface UserRow {
   focus_energy_mode: FocusEnergyMode;
   /** While saved mode is focus: which desk owner's chair upgrades apply for offline settlement. */
   focus_energy_desk_owner_email: string | null;
+  /** Purchased desk decoration placements. */
+  desk_items: DeskItemPlacement[];
 }
 
 interface RoomRow {
@@ -85,6 +88,7 @@ function defaultUserRow(): UserRow {
     focus_energy_updated_at: now,
     focus_energy_mode: "idle",
     focus_energy_desk_owner_email: null,
+    desk_items: [],
   };
 }
 
@@ -410,20 +414,69 @@ export async function memPurchaseMonitorUpgrade(email: string): Promise<MemMonit
   return { ok: true, paperReams: u.paper_reams, monitorUpgradeLevel: u.monitor_upgrade_level };
 }
 
-export type MemTeamPyramidPurchaseResult =
-  | { ok: true; paperReams: number }
-  | { ok: false; error: "insufficient" };
-
-export async function memPurchaseTeamPyramid(email: string): Promise<MemTeamPyramidPurchaseResult> {
+/** Deduct reams for a team upgrade contribution (replaces single-payer pyramid purchase). */
+export async function memDeductReamsForTeamContribution(
+  email: string,
+  amount: number
+): Promise<{ ok: true; paperReams: number } | { ok: false; error: "insufficient" }> {
   const u = users.get(email) ?? defaultUserRow();
-  if (u.paper_reams < TEAM_PYRAMID_COST_REAMS) return { ok: false, error: "insufficient" };
-  u.paper_reams -= TEAM_PYRAMID_COST_REAMS;
+  if (u.paper_reams < amount) return { ok: false, error: "insufficient" };
+  u.paper_reams -= amount;
   u.total_paper_reams_earned = Math.max(
     u.total_paper_reams_earned,
     totalPaperReamsEarnedFloor(u.paper_reams, u.chair_upgrade_level, u.monitor_upgrade_level)
   );
   users.set(email, u);
   return { ok: true, paperReams: u.paper_reams };
+}
+
+export async function memGetDeskItemsForEmails(
+  emails: string[]
+): Promise<Record<string, DeskItemPlacement[]>> {
+  const out: Record<string, DeskItemPlacement[]> = {};
+  for (const e of emails) {
+    const row = users.get(e);
+    out[e] = row?.desk_items ?? [];
+  }
+  return out;
+}
+
+export type MemDeskItemPurchaseResult =
+  | { ok: true; paperReams: number; items: DeskItemPlacement[] }
+  | { ok: false; error: "already_owned" | "insufficient" | "not_found" };
+
+export async function memPurchaseDeskItem(
+  email: string,
+  itemId: string,
+  cost: number
+): Promise<MemDeskItemPurchaseResult> {
+  const def = DESK_ITEM_CATALOG.find((d) => d.id === itemId);
+  if (!def) return { ok: false, error: "not_found" };
+  const u = users.get(email) ?? defaultUserRow();
+  if (u.desk_items.some((i) => i.id === itemId)) return { ok: false, error: "already_owned" };
+  if (u.paper_reams < cost) return { ok: false, error: "insufficient" };
+  u.paper_reams -= cost;
+  u.desk_items = [...u.desk_items, { id: itemId, x: 0, z: 0 }];
+  u.total_paper_reams_earned = Math.max(
+    u.total_paper_reams_earned,
+    totalPaperReamsEarnedFloor(u.paper_reams, u.chair_upgrade_level, u.monitor_upgrade_level)
+  );
+  users.set(email, u);
+  return { ok: true, paperReams: u.paper_reams, items: u.desk_items };
+}
+
+export async function memSaveDeskItemPositions(
+  email: string,
+  items: DeskItemPlacement[]
+): Promise<{ ok: true }> {
+  const u = users.get(email) ?? defaultUserRow();
+  u.desk_items = items.map((item) => ({
+    id: item.id,
+    x: Math.max(-1, Math.min(1, item.x)),
+    z: Math.max(-0.4, Math.min(0.4, item.z)),
+  }));
+  users.set(email, u);
+  return { ok: true };
 }
 
 export async function memUpdateRoomMaxWorkers(roomId: string, maxWorkers: number): Promise<void> {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -414,6 +414,7 @@ export default function App() {
         <ComputerInterface
           onClose={() => setShowComputerInterface(false)}
           onOpenAdminPanel={() => { setShowComputerInterface(false); setShowAdminPanel(true); }}
+          socket={socket}
         />
       )}
 

--- a/src/__tests__/integration/server.test.ts
+++ b/src/__tests__/integration/server.test.ts
@@ -15,7 +15,7 @@ import request from 'supertest';
 import { io as ioc, type Socket } from 'socket.io-client';
 import type { AddressInfo } from 'net';
 import type pg from 'pg';
-import { TEAM_PYRAMID_DURATION_MS } from '../../gameConfig.js';
+import { TEAM_PYRAMID_COST_REAMS, TEAM_PYRAMID_DURATION_MS } from '../../gameConfig.js';
 
 // Static import so that dotenv.config() in server.ts runs exactly once (at
 // file load time), before any test manipulates process.env. Dynamic
@@ -256,6 +256,7 @@ function waitFor<T = unknown>(socket: Socket, event: string, timeout = 3000): Pr
 function emitWithAck<T = unknown>(
   socket: Socket,
   event: string,
+  data?: unknown,
   timeout = 3000
 ): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -263,10 +264,12 @@ function emitWithAck<T = unknown>(
       () => reject(new Error(`Timed out waiting for ack from "${event}"`)),
       timeout
     );
-    socket.emit(event, (payload: T) => {
-      clearTimeout(timer);
-      resolve(payload);
-    });
+    const cb = (payload: T) => { clearTimeout(timer); resolve(payload); };
+    if (data !== undefined) {
+      socket.emit(event, data, cb);
+    } else {
+      socket.emit(event, cb);
+    }
   });
 }
 
@@ -558,7 +561,7 @@ describe('Socket.IO — playerFocusUpdate identity-theft system chat', () => {
   });
 });
 
-describe('Socket.IO — purchaseTeamPyramid', () => {
+describe('Socket.IO — contributeTeamUpgrade (pyramid)', () => {
   let httpServer: any;
   let buyer: Socket;
   let watcher: Socket;
@@ -592,20 +595,22 @@ describe('Socket.IO — purchaseTeamPyramid', () => {
     delete process.env.DEV_USER_EMAIL;
   });
 
-  it('extends an already-active Team Pyramid buff by another full duration', async () => {
+  it('activates the buff and sets expiresAt when contribution reaches the target', async () => {
     buyer = connectAs(buyerEmail);
     await waitFor(buyer, 'connect');
     buyer.emit('joinRoom', { roomId });
     await waitFor(buyer, 'currentPlayers');
 
-    const first = await emitWithAck<{ ok: boolean; expiresAt?: number }>(buyer, 'purchaseTeamPyramid');
-    const second = await emitWithAck<{ ok: boolean; expiresAt?: number }>(buyer, 'purchaseTeamPyramid');
+    const before = Date.now();
+    const result = await emitWithAck<{ ok: boolean; pool?: { expiresAt: number | null } }>(
+      buyer,
+      'contributeTeamUpgrade',
+      { upgradeType: 'pyramid', amount: TEAM_PYRAMID_COST_REAMS }
+    );
 
-    expect(first.ok).toBe(true);
-    expect(second.ok).toBe(true);
-    expect(typeof first.expiresAt).toBe('number');
-    expect(typeof second.expiresAt).toBe('number');
-    expect((second.expiresAt as number) - (first.expiresAt as number)).toBe(TEAM_PYRAMID_DURATION_MS);
+    expect(result.ok).toBe(true);
+    expect(typeof result.pool?.expiresAt).toBe('number');
+    expect(result.pool!.expiresAt!).toBeGreaterThanOrEqual(before + TEAM_PYRAMID_DURATION_MS - 100);
   });
 
   it('broadcasts the pyramid system message to chat for everyone in the room', async () => {
@@ -621,9 +626,13 @@ describe('Socket.IO — purchaseTeamPyramid', () => {
 
     const buyerMessagePromise = waitFor<any>(buyer, 'chatMessage');
     const watcherMessagePromise = waitFor<any>(watcher, 'chatMessage');
-    const purchase = await emitWithAck<{ ok: boolean }>(buyer, 'purchaseTeamPyramid');
+    const result = await emitWithAck<{ ok: boolean }>(
+      buyer,
+      'contributeTeamUpgrade',
+      { upgradeType: 'pyramid', amount: TEAM_PYRAMID_COST_REAMS }
+    );
 
-    expect(purchase.ok).toBe(true);
+    expect(result.ok).toBe(true);
     const [buyerMsg, watcherMsg] = await Promise.all([buyerMessagePromise, watcherMessagePromise]);
     expect(buyerMsg).toMatchObject({
       playerId: 'system',

--- a/src/__tests__/unit/constants.test.ts
+++ b/src/__tests__/unit/constants.test.ts
@@ -11,7 +11,21 @@ vi.mock('three', async (importOriginal) => {
     setFromCenterAndSize: vi.fn().mockReturnThis(),
   }));
   const MockVector3 = vi.fn().mockImplementation((x = 0, y = 0, z = 0) => vec3(x, y, z));
-  return { ...actual, Box3: MockBox3, Vector3: MockVector3 };
+  const MockMaterial = vi.fn().mockImplementation(() => ({}));
+  const MockGeometry = vi.fn().mockImplementation(() => ({}));
+  return {
+    ...actual,
+    Box3: MockBox3,
+    Vector3: MockVector3,
+    MeshStandardMaterial: MockMaterial,
+    MeshBasicMaterial: MockMaterial,
+    Color: vi.fn().mockImplementation(() => ({})),
+    SphereGeometry: MockGeometry,
+    ConeGeometry: MockGeometry,
+    Ray: vi.fn().mockImplementation(() => ({})),
+    AdditiveBlending: 2,
+    DoubleSide: 2,
+  };
 });
 
 // Dynamic import is required here: vi.mock is hoisted but a static import

--- a/src/components/ui/ComputerInterface.tsx
+++ b/src/components/ui/ComputerInterface.tsx
@@ -1,13 +1,50 @@
-import React, { useEffect, useState } from 'react';
-import { X, Settings, FileText, Clock, Wifi } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
+import { X, Settings, FileText, Clock, Wifi, Monitor, ShoppingBag, Users } from 'lucide-react';
+import type { Socket } from 'socket.io-client';
 import { useGameStore } from '../../store/useGameStore';
+import { DESK_ITEM_CATALOG } from '../../deskItemCatalog';
+import { TEAM_UPGRADE_DEFS } from '../../teamUpgradeDefs';
+import {
+  CHAIR_UPGRADE_COST_REAMS,
+  CHAIR_UPGRADE_MAX_LEVEL,
+} from '../../chairUpgradeConstants';
+import {
+  MONITOR_UPGRADE_MAX_LEVEL,
+  monitorUpgradeCostForNextLevel,
+} from '../../monitorUpgradeConstants';
+import {
+  FOCUS_ENERGY_SEATED_REGEN_MAX_PER_MIN,
+  FOCUS_ENERGY_SEATED_REGEN_PER_CHAIR_LEVEL_PER_MIN,
+} from '../../focusEnergyModel';
+import type { DeskItemPlacement } from '../../types';
+
+type Tab = 'dashboard' | 'upgrades' | 'shop' | 'perks';
 
 interface ComputerInterfaceProps {
   onClose: () => void;
   onOpenAdminPanel: () => void;
+  socket: Socket | null;
 }
 
-export const ComputerInterface = ({ onClose, onOpenAdminPanel }: ComputerInterfaceProps) => {
+// ── Upgrade purchase ack types ───────────────────────────────────────────────
+type ChairPurchaseAck =
+  | { ok: true; paperReams: number; chairUpgradeLevel: number }
+  | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
+
+type MonitorPurchaseAck =
+  | { ok: true; paperReams: number; monitorUpgradeLevel: number }
+  | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
+
+type DeskItemPurchaseAck =
+  | { ok: true; paperReams: number; items: DeskItemPlacement[] }
+  | { ok: false; error: 'already_owned' | 'insufficient' | 'not_found' | 'not_in_room' | 'server_error' };
+
+type ContributeAck =
+  | { ok: true; paperReams: number; pool: import('../../types').TeamUpgradePool }
+  | { ok: false; error: string };
+
+// ── Dashboard tab ────────────────────────────────────────────────────────────
+function DashboardTab({ onClose, onOpenAdminPanel }: { onClose: () => void; onOpenAdminPanel: () => void }) {
   const user = useGameStore((s) => s.user);
   const paperReams = useGameStore((s) => s.paperReams);
   const isTimerActive = useGameStore((s) => s.isTimerActive);
@@ -22,12 +59,6 @@ export const ComputerInterface = ({ onClose, onOpenAdminPanel }: ComputerInterfa
     return () => clearInterval(t);
   }, []);
 
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' || e.key === 'f' || e.key === 'F') onClose(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
   const formatTime = (secs: number) => {
     const m = Math.floor(secs / 60).toString().padStart(2, '0');
     const s = (secs % 60).toString().padStart(2, '0');
@@ -37,115 +68,646 @@ export const ComputerInterface = ({ onClose, onOpenAdminPanel }: ComputerInterfa
   const displayName = user?.name ?? user?.email?.split('@')[0] ?? 'Employee';
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/80">
-      {/* Monitor bezel */}
-      <div className="bg-[#1a1a2e] border-4 border-[#333] rounded-lg shadow-2xl w-[700px] max-h-[85vh] overflow-hidden flex flex-col"
-           style={{ boxShadow: '0 0 40px rgba(0,200,255,0.15), inset 0 0 60px rgba(0,0,0,0.5)' }}>
+    <div className="flex flex-col gap-5">
+      <div className="border border-[#00c8ff]/30 bg-[#00c8ff]/5 px-5 py-4 rounded">
+        <div className="text-[#00c8ff] text-sm mb-1">
+          Welcome back, <span className="text-white font-bold">{displayName}</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Wifi className="w-3 h-3 text-emerald-400" />
+          <span className="text-emerald-400 text-[10px] tracking-widest uppercase">Connected — {roomId ?? 'Office'}</span>
+          {myRole && (
+            <span className={`ml-2 text-[9px] px-2 py-0.5 rounded border ${
+              myRole === 'admin' ? 'border-amber-400/50 text-amber-400 bg-amber-400/10' :
+              myRole === 'manager' ? 'border-indigo-400/50 text-indigo-400 bg-indigo-400/10' :
+              'border-slate-400/50 text-slate-400 bg-slate-400/10'
+            } uppercase tracking-widest`}>
+              {myRole}
+            </span>
+          )}
+          <span className="ml-auto text-[#00c8ff]/50 text-[10px]">{time.toLocaleTimeString()}</span>
+        </div>
+      </div>
 
-        {/* Screen scanline overlay */}
-        <div className="absolute inset-0 pointer-events-none rounded-lg"
-             style={{ background: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px)' }} />
+      <div className="grid grid-cols-2 gap-4">
+        <div className="border border-[#00c8ff]/20 bg-[#00c8ff]/5 p-4 rounded">
+          <div className="flex items-center gap-2 mb-3">
+            <FileText className="w-3.5 h-3.5 text-[#00c8ff]/60" />
+            <span className="text-[#00c8ff]/60 text-[9px] uppercase tracking-widest">Sales Performance</span>
+          </div>
+          <div className="text-3xl font-bold text-white">{paperReams.toLocaleString()}</div>
+          <div className="text-[#00c8ff]/40 text-[9px] mt-1 uppercase tracking-widest">Reams Sold</div>
+        </div>
+
+        <div className="border border-[#00c8ff]/20 bg-[#00c8ff]/5 p-4 rounded">
+          <div className="flex items-center gap-2 mb-3">
+            <Clock className="w-3.5 h-3.5 text-[#00c8ff]/60" />
+            <span className="text-[#00c8ff]/60 text-[9px] uppercase tracking-widest">Focus Session</span>
+          </div>
+          {isTimerActive ? (
+            <>
+              <div className="text-3xl font-bold text-emerald-400">{formatTime(timeLeft)}</div>
+              <div className="text-emerald-400/60 text-[9px] mt-1 uppercase tracking-widest">
+                Active · +{sessionPaper} reams this session
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="text-3xl font-bold text-[#00c8ff]/30">--:--</div>
+              <div className="text-[#00c8ff]/30 text-[9px] mt-1 uppercase tracking-widest">No active session</div>
+            </>
+          )}
+        </div>
+      </div>
+
+      {(myRole === 'admin' || myRole === 'manager') && (
+        <div className="border border-amber-400/30 bg-amber-400/5 p-4 rounded">
+          <div className="flex items-center gap-2 mb-3">
+            <Settings className="w-3.5 h-3.5 text-amber-400/70" />
+            <span className="text-amber-400/70 text-[9px] uppercase tracking-widest">Office Management</span>
+          </div>
+          <p className="text-[#00c8ff]/50 text-[10px] mb-4 leading-relaxed">
+            Manage office members, assign roles, and configure workspace settings.
+          </p>
+          <button
+            onClick={() => { onClose(); onOpenAdminPanel(); }}
+            className="flex items-center gap-2 px-4 py-2.5 bg-amber-400/20 hover:bg-amber-400/30 border border-amber-400/40 text-amber-300 text-[10px] uppercase tracking-widest rounded transition-all"
+          >
+            <Settings className="w-3 h-3" />
+            Manage Office
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Upgrades tab ─────────────────────────────────────────────────────────────
+function UpgradesTab({ socket }: { socket: Socket | null }) {
+  const user = useGameStore((s) => s.user);
+  const paperReams = useGameStore((s) => s.paperReams);
+  const chairLevelByEmail = useGameStore((s) => s.chairLevelByEmail);
+  const monitorLevelByEmail = useGameStore((s) => s.monitorLevelByEmail);
+  const setPaperReams = useGameStore((s) => s.setPaperReams);
+  const patchChairLevel = useGameStore((s) => s.patchChairLevel);
+  const patchMonitorLevel = useGameStore((s) => s.patchMonitorLevel);
+
+  const myChairLevel = user?.email ? (chairLevelByEmail[user.email] ?? 0) : 0;
+  const chairMaxed = myChairLevel >= CHAIR_UPGRADE_MAX_LEVEL;
+  const canAffordChair = paperReams >= CHAIR_UPGRADE_COST_REAMS;
+
+  const myMonitorLevel = user?.email ? (monitorLevelByEmail[user.email] ?? 0) : 0;
+  const monitorMaxed = myMonitorLevel >= MONITOR_UPGRADE_MAX_LEVEL;
+  const nextMonitorCost = monitorMaxed ? 0 : monitorUpgradeCostForNextLevel(myMonitorLevel);
+  const canAffordMonitor = !monitorMaxed && paperReams >= nextMonitorCost;
+
+  const socketOk = socket?.connected === true;
+
+  const [chairBusy, setChairBusy] = useState(false);
+  const [chairFeedback, setChairFeedback] = useState<string | null>(null);
+  const [monitorBusy, setMonitorBusy] = useState(false);
+  const [monitorFeedback, setMonitorFeedback] = useState<string | null>(null);
+
+  const handleBuyChair = () => {
+    setChairFeedback(null);
+    if (!socketOk) { setChairFeedback('offline'); return; }
+    if (chairMaxed) { setChairFeedback('max_level'); return; }
+    if (!canAffordChair) { setChairFeedback('insufficient'); return; }
+    setChairBusy(true);
+    socket!.timeout(12_000).emit('purchaseChairUpgrade', (err: Error | null, res: unknown) => {
+      setChairBusy(false);
+      if (err) { setChairFeedback('server_error'); return; }
+      const r = res as ChairPurchaseAck;
+      if (!r || typeof r !== 'object') { setChairFeedback('server_error'); return; }
+      if (r.ok) {
+        setPaperReams(r.paperReams);
+        if (user?.email) patchChairLevel(user.email, r.chairUpgradeLevel);
+      } else {
+        setChairFeedback((r as { ok: false; error: string }).error);
+      }
+    });
+  };
+
+  const handleBuyMonitor = () => {
+    setMonitorFeedback(null);
+    if (!socketOk) { setMonitorFeedback('offline'); return; }
+    if (monitorMaxed) { setMonitorFeedback('max_level'); return; }
+    if (!canAffordMonitor) { setMonitorFeedback('insufficient'); return; }
+    setMonitorBusy(true);
+    socket!.timeout(12_000).emit('purchaseMonitorUpgrade', (err: Error | null, res: unknown) => {
+      setMonitorBusy(false);
+      if (err) { setMonitorFeedback('server_error'); return; }
+      const r = res as MonitorPurchaseAck;
+      if (!r || typeof r !== 'object') { setMonitorFeedback('server_error'); return; }
+      if (r.ok) {
+        setPaperReams(r.paperReams);
+        if (user?.email) patchMonitorLevel(user.email, r.monitorUpgradeLevel);
+      } else {
+        setMonitorFeedback((r as { ok: false; error: string }).error);
+      }
+    });
+  };
+
+  const feedbackMsg = (code: string | null) => {
+    if (!code) return null;
+    const map: Record<string, string> = {
+      insufficient: 'Not enough reams.',
+      max_level: 'Already at max level.',
+      not_in_room: 'Join the office room first.',
+      server_error: 'Could not complete — try again.',
+      offline: 'Not connected.',
+    };
+    return map[code] ?? 'Unknown error.';
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-[#00c8ff]/40 text-[10px] font-mono">Balance: <span className="text-amber-200">{paperReams.toLocaleString()}</span> reams</p>
+
+      {/* Chair */}
+      <div className="border border-amber-600/40 bg-amber-950/25 p-4 rounded">
+        <div className="flex items-start justify-between gap-4 mb-3">
+          <div>
+            <p className="text-amber-100 text-[10px] font-pixel mb-1">Desk Chair Upgrade</p>
+            <p className="text-slate-400 text-[10px] leading-snug">
+              Bigger seat, gold trim, studs &amp; plants — visible to everyone at your desk.
+            </p>
+            <p className="text-slate-500 text-[9px] mt-1">
+              Seated focus: +{FOCUS_ENERGY_SEATED_REGEN_PER_CHAIR_LEVEL_PER_MIN}/min per level
+              (max +{FOCUS_ENERGY_SEATED_REGEN_MAX_PER_MIN}/min at lv {CHAIR_UPGRADE_MAX_LEVEL})
+            </p>
+            <p className="text-amber-200 text-[9px] mt-1">Level {myChairLevel} / {CHAIR_UPGRADE_MAX_LEVEL}</p>
+          </div>
+          <span className="text-amber-300 text-sm shrink-0 font-mono">{CHAIR_UPGRADE_COST_REAMS} reams</span>
+        </div>
+        <button
+          onClick={handleBuyChair}
+          disabled={!socketOk || chairMaxed || chairBusy}
+          className="pixel-button font-pixel text-[8px] w-full disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {chairMaxed ? 'Chair fully upgraded' : chairBusy ? 'Processing…' : `Upgrade chair (${CHAIR_UPGRADE_COST_REAMS} reams)`}
+        </button>
+        {chairFeedback && <p className="text-rose-400/90 text-[10px] font-mono mt-2">{feedbackMsg(chairFeedback)}</p>}
+      </div>
+
+      {/* Monitor */}
+      <div className="border border-cyan-700/40 bg-cyan-950/20 p-4 rounded">
+        <div className="flex items-start justify-between gap-4 mb-3">
+          <div>
+            <p className="text-cyan-100 text-[10px] font-pixel mb-1">Desk Monitors</p>
+            <p className="text-slate-400 text-[10px] leading-snug">
+              Add a screen each time (up to 8). First 3 upgrades also add +1 ream/min while focusing.
+            </p>
+            <p className="text-cyan-200 text-[9px] mt-1">
+              {myMonitorLevel} / {MONITOR_UPGRADE_MAX_LEVEL} upgrades ({1 + myMonitorLevel} monitors)
+              {!monitorMaxed && <span className="text-slate-500"> → next: {nextMonitorCost} reams</span>}
+            </p>
+          </div>
+          {!monitorMaxed && <span className="text-cyan-300 text-sm shrink-0 font-mono">{nextMonitorCost} reams</span>}
+        </div>
+        <button
+          onClick={handleBuyMonitor}
+          disabled={!socketOk || monitorMaxed || monitorBusy}
+          className="pixel-button font-pixel text-[8px] w-full disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {monitorMaxed ? 'Monitors maxed (8 screens)' : monitorBusy ? 'Processing…' : `Add monitor (${nextMonitorCost} reams)`}
+        </button>
+        {monitorFeedback && <p className="text-rose-400/90 text-[10px] font-mono mt-2">{feedbackMsg(monitorFeedback)}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ── Desk Shop tab ─────────────────────────────────────────────────────────────
+const DESK_W = 280; // px, SVG viewport
+const DESK_H = 140; // px, SVG viewport
+
+function DeskShopTab({ socket }: { socket: Socket | null }) {
+  const user = useGameStore((s) => s.user);
+  const paperReams = useGameStore((s) => s.paperReams);
+  const deskItemsByEmail = useGameStore((s) => s.deskItemsByEmail);
+  const setPaperReams = useGameStore((s) => s.setPaperReams);
+  const patchDeskItems = useGameStore((s) => s.patchDeskItems);
+
+  const myItems: DeskItemPlacement[] = user?.email ? (deskItemsByEmail[user.email] ?? []) : [];
+  const socketOk = socket?.connected === true;
+
+  const [buyFeedback, setBuyFeedback] = useState<Record<string, string>>({});
+  const [buyBusy, setBuyBusy] = useState<Record<string, boolean>>({});
+
+  // Rearrange state
+  const [editItems, setEditItems] = useState<DeskItemPlacement[] | null>(null);
+  const draggingIdx = useRef<number | null>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const activeItems = editItems ?? myItems;
+
+  const handleBuy = (itemId: string, cost: number) => {
+    setBuyFeedback((f) => ({ ...f, [itemId]: '' }));
+    if (!socketOk) { setBuyFeedback((f) => ({ ...f, [itemId]: 'Not connected.' })); return; }
+    if (paperReams < cost) { setBuyFeedback((f) => ({ ...f, [itemId]: 'Not enough reams.' })); return; }
+    setBuyBusy((b) => ({ ...b, [itemId]: true }));
+    socket!.timeout(12_000).emit('purchaseDeskItem', { itemId }, (err: Error | null, res: unknown) => {
+      setBuyBusy((b) => ({ ...b, [itemId]: false }));
+      if (err) { setBuyFeedback((f) => ({ ...f, [itemId]: 'Server error — try again.' })); return; }
+      const r = res as DeskItemPurchaseAck;
+      if (!r || typeof r !== 'object') { setBuyFeedback((f) => ({ ...f, [itemId]: 'Server error — try again.' })); return; }
+      if (r.ok) {
+        setPaperReams(r.paperReams);
+        if (user?.email) patchDeskItems(user.email, r.items);
+      } else {
+        const msgs: Record<string, string> = {
+          already_owned: 'Already owned.',
+          insufficient: 'Not enough reams.',
+          not_found: 'Item not found.',
+          not_in_room: 'Join the office room first.',
+          server_error: 'Server error — try again.',
+        };
+        const errCode = (r as { ok: false; error: string }).error;
+        setBuyFeedback((f) => ({ ...f, [itemId]: msgs[errCode] ?? 'Unknown error.' }));
+      }
+    });
+  };
+
+  // ── SVG drag rearrange ──────────────────────────────────────────────────
+  // Map desk local coords (-1..1 x, -0.4..0.4 z) to SVG px
+  const toSvg = (x: number, z: number) => ({
+    svgX: ((x + 1) / 2) * DESK_W,
+    svgY: ((z + 0.4) / 0.8) * DESK_H,
+  });
+  const fromSvg = (svgX: number, svgY: number) => ({
+    x: Math.max(-1, Math.min(1, (svgX / DESK_W) * 2 - 1)),
+    z: Math.max(-0.4, Math.min(0.4, (svgY / DESK_H) * 0.8 - 0.4)),
+  });
+
+  const onSvgPointerDown = (e: React.PointerEvent<SVGCircleElement>, idx: number) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    draggingIdx.current = idx;
+    if (!editItems) setEditItems([...myItems]);
+  };
+
+  const onSvgPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (draggingIdx.current == null || !svgRef.current) return;
+    const rect = svgRef.current.getBoundingClientRect();
+    const svgX = e.clientX - rect.left;
+    const svgY = e.clientY - rect.top;
+    const { x, z } = fromSvg(svgX, svgY);
+    setEditItems((prev) => {
+      const base = prev ?? [...myItems];
+      return base.map((item, i) => i === draggingIdx.current ? { ...item, x, z } : item);
+    });
+  };
+
+  const onSvgPointerUp = () => {
+    draggingIdx.current = null;
+  };
+
+  const handleSavePositions = () => {
+    if (!editItems || !socketOk || !user?.email) return;
+    socket!.timeout(8_000).emit('saveDeskItemPositions', { items: editItems }, (err: Error | null, res: unknown) => {
+      if (!err && (res as { ok?: boolean })?.ok) {
+        patchDeskItems(user.email!, editItems);
+        setEditItems(null);
+      }
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[#00c8ff]/40 text-[10px] font-mono">Balance: <span className="text-amber-200">{paperReams.toLocaleString()}</span> reams</p>
+
+      {DESK_ITEM_CATALOG.map((def) => {
+        const owned = myItems.some((i) => i.id === def.id);
+        const busy = buyBusy[def.id] ?? false;
+        const fb = buyFeedback[def.id];
+        return (
+          <div key={def.id} className="border border-yellow-600/30 bg-yellow-950/20 p-4 rounded">
+            <div className="flex items-start justify-between gap-4 mb-2">
+              <div>
+                <p className="text-yellow-100 text-[10px] font-pixel mb-1">🏆 {def.name}</p>
+                <p className="text-slate-400 text-[10px] leading-snug">{def.description}</p>
+              </div>
+              {!owned && <span className="text-yellow-300 text-sm shrink-0 font-mono">{def.cost} reams</span>}
+              {owned && <span className="text-emerald-400 text-[9px] font-mono shrink-0 uppercase tracking-widest">Owned</span>}
+            </div>
+            {!owned && (
+              <button
+                onClick={() => handleBuy(def.id, def.cost)}
+                disabled={!socketOk || busy || paperReams < def.cost}
+                className="pixel-button font-pixel text-[8px] w-full disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {busy ? 'Processing…' : `Buy (${def.cost} reams)`}
+              </button>
+            )}
+            {fb && <p className="text-rose-400/90 text-[10px] font-mono mt-2">{fb}</p>}
+          </div>
+        );
+      })}
+
+      {/* Rearrange SVG */}
+      {myItems.length > 0 && (
+        <div className="border border-[#00c8ff]/20 bg-[#00c8ff]/5 p-4 rounded">
+          <p className="text-[#00c8ff]/70 text-[9px] uppercase tracking-widest mb-3">Rearrange desk items</p>
+          <p className="text-slate-500 text-[9px] mb-3">Drag items to reposition them on your desk surface.</p>
+          <svg
+            ref={svgRef}
+            width={DESK_W}
+            height={DESK_H}
+            className="rounded border border-[#8B4513]/60 cursor-crosshair"
+            style={{ background: '#5c2d0a', display: 'block', maxWidth: '100%' }}
+            onPointerMove={onSvgPointerMove}
+            onPointerUp={onSvgPointerUp}
+            onPointerLeave={onSvgPointerUp}
+          >
+            {/* Desk surface grid lines */}
+            <line x1={DESK_W / 2} y1={0} x2={DESK_W / 2} y2={DESK_H} stroke="#ffffff10" strokeWidth={1} />
+            <line x1={0} y1={DESK_H / 2} x2={DESK_W} y2={DESK_H / 2} stroke="#ffffff10" strokeWidth={1} />
+            {/* Items */}
+            {activeItems.map((item, i) => {
+              const def = DESK_ITEM_CATALOG.find((d) => d.id === item.id);
+              const { svgX, svgY } = toSvg(item.x, item.z);
+              return (
+                <g key={item.id} transform={`translate(${svgX},${svgY})`}>
+                  <circle
+                    r={14}
+                    fill="#FFD700"
+                    stroke="#b8860b"
+                    strokeWidth={2}
+                    style={{ cursor: 'grab' }}
+                    onPointerDown={(e) => onSvgPointerDown(e, i)}
+                  />
+                  <text
+                    textAnchor="middle"
+                    dominantBaseline="middle"
+                    fontSize={10}
+                    fill="#1a0f00"
+                    style={{ userSelect: 'none', pointerEvents: 'none' }}
+                  >
+                    {def?.name.slice(0, 3) ?? '?'}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+          {editItems && (
+            <div className="flex gap-2 mt-3">
+              <button
+                onClick={handleSavePositions}
+                disabled={!socketOk}
+                className="pixel-button font-pixel text-[8px] flex-1 disabled:opacity-50"
+              >
+                Save positions
+              </button>
+              <button
+                onClick={() => setEditItems(null)}
+                className="pixel-button font-pixel text-[8px] flex-1"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Company Perks tab ─────────────────────────────────────────────────────────
+function PerksTab({ socket }: { socket: Socket | null }) {
+  const user = useGameStore((s) => s.user);
+  const paperReams = useGameStore((s) => s.paperReams);
+  const teamUpgradePools = useGameStore((s) => s.teamUpgradePools);
+  const setPaperReams = useGameStore((s) => s.setPaperReams);
+  const patchTeamUpgradePool = useGameStore((s) => s.patchTeamUpgradePool);
+
+  const socketOk = socket?.connected === true;
+  const [contributions, setContributions] = useState<Record<string, string>>({});
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  const [feedback, setFeedback] = useState<Record<string, string>>({});
+
+  const handleContribute = (upgradeType: string) => {
+    const raw = contributions[upgradeType] ?? '';
+    const amount = Math.floor(Number(raw));
+    if (!amount || amount <= 0) { setFeedback((f) => ({ ...f, [upgradeType]: 'Enter a valid amount.' })); return; }
+    if (!socketOk) { setFeedback((f) => ({ ...f, [upgradeType]: 'Not connected.' })); return; }
+    if (paperReams < amount) { setFeedback((f) => ({ ...f, [upgradeType]: 'Not enough reams.' })); return; }
+    setBusy((b) => ({ ...b, [upgradeType]: true }));
+    setFeedback((f) => ({ ...f, [upgradeType]: '' }));
+    socket!.timeout(12_000).emit(
+      'contributeTeamUpgrade',
+      { upgradeType, amount },
+      (err: Error | null, res: unknown) => {
+        setBusy((b) => ({ ...b, [upgradeType]: false }));
+        if (err) { setFeedback((f) => ({ ...f, [upgradeType]: 'Server error — try again.' })); return; }
+        const r = res as ContributeAck;
+        if (!r || typeof r !== 'object') { setFeedback((f) => ({ ...f, [upgradeType]: 'Server error — try again.' })); return; }
+        if (r.ok) {
+          setPaperReams(r.paperReams);
+          patchTeamUpgradePool(upgradeType, r.pool);
+          setContributions((c) => ({ ...c, [upgradeType]: '' }));
+        } else {
+          const msgs: Record<string, string> = {
+            insufficient: 'Not enough reams.',
+            not_in_room: 'Join the office room first.',
+            invalid: 'Invalid contribution.',
+            server_error: 'Server error — try again.',
+          };
+          const errCode = (r as { ok: false; error: string }).error;
+          setFeedback((f) => ({ ...f, [upgradeType]: msgs[errCode] ?? 'Unknown error.' }));
+        }
+      }
+    );
+  };
+
+  const formatCountdown = (expiresAt: number) => {
+    const ms = Math.max(0, expiresAt - Date.now());
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.floor((ms % 3_600_000) / 60_000);
+    const s = Math.floor((ms % 60_000) / 1000);
+    return `${h}h ${m}m ${s}s`;
+  };
+
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, []);
+  void tick; // suppress unused warning — only used to trigger re-render for countdown
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[#00c8ff]/40 text-[10px] font-mono">
+        Balance: <span className="text-amber-200">{paperReams.toLocaleString()}</span> reams
+      </p>
+
+      {Object.entries(TEAM_UPGRADE_DEFS).map(([upgradeType, def]) => {
+        const pool = teamUpgradePools[upgradeType];
+        const contributed = pool?.contributed ?? 0;
+        const target = pool?.target ?? def.target;
+        const expiresAt = pool?.expiresAt ?? null;
+        const isActive = expiresAt != null && Date.now() < expiresAt;
+        const progress = Math.min(1, contributed / target);
+        const topContributors = pool
+          ? Object.entries(pool.contributors)
+              .sort((a, b) => b[1] - a[1])
+              .slice(0, 3)
+          : [];
+        const myContrib = user?.email ? (pool?.contributors[user.email] ?? 0) : 0;
+
+        return (
+          <div key={upgradeType} className="border border-fuchsia-600/40 bg-fuchsia-950/20 p-4 rounded">
+            <div className="flex items-start justify-between gap-2 mb-2">
+              <p className="text-fuchsia-100 text-[10px] font-pixel">{def.displayName}</p>
+              {isActive && (
+                <span className="text-emerald-400 text-[9px] font-mono shrink-0">Active</span>
+              )}
+            </div>
+            <p className="text-slate-400 text-[10px] leading-snug mb-3">{def.description}</p>
+
+            {isActive ? (
+              <div className="space-y-1">
+                <p className="text-emerald-400 text-[10px] font-mono">
+                  Expires in: {formatCountdown(expiresAt!)}
+                </p>
+                <p className="text-slate-500 text-[9px]">
+                  Contributions reset when the buff expires.
+                </p>
+              </div>
+            ) : (
+              <>
+                {/* Progress bar */}
+                <div className="mb-2">
+                  <div className="flex justify-between text-[9px] font-mono mb-1">
+                    <span className="text-slate-400">{contributed.toLocaleString()} / {target.toLocaleString()} reams</span>
+                    <span className="text-fuchsia-300">{Math.round(progress * 100)}%</span>
+                  </div>
+                  <div className="w-full h-2 bg-fuchsia-950/60 rounded overflow-hidden border border-fuchsia-800/40">
+                    <div
+                      className="h-full bg-fuchsia-500 transition-all"
+                      style={{ width: `${progress * 100}%` }}
+                    />
+                  </div>
+                </div>
+
+                {/* Top contributors */}
+                {topContributors.length > 0 && (
+                  <div className="mb-3">
+                    <p className="text-[9px] text-slate-500 uppercase tracking-widest mb-1">Contributors</p>
+                    {topContributors.map(([email, amt]) => (
+                      <p key={email} className="text-[9px] font-mono text-slate-400">
+                        {email.split('@')[0]}: <span className="text-fuchsia-300">{amt.toLocaleString()}</span>
+                      </p>
+                    ))}
+                  </div>
+                )}
+                {myContrib > 0 && (
+                  <p className="text-[9px] font-mono text-slate-500 mb-3">Your contribution: <span className="text-fuchsia-300">{myContrib.toLocaleString()}</span></p>
+                )}
+
+                {/* Contribution input */}
+                <div className="flex gap-2">
+                  <input
+                    type="number"
+                    min={1}
+                    max={paperReams}
+                    value={contributions[upgradeType] ?? ''}
+                    onChange={(e) => setContributions((c) => ({ ...c, [upgradeType]: e.target.value }))}
+                    placeholder="Amount"
+                    className="flex-1 bg-fuchsia-950/40 border border-fuchsia-700/40 text-white text-[10px] font-mono px-2 py-1 rounded focus:outline-none focus:border-fuchsia-400/60"
+                  />
+                  <button
+                    onClick={() => handleContribute(upgradeType)}
+                    disabled={!socketOk || (busy[upgradeType] ?? false)}
+                    className="pixel-button font-pixel text-[8px] px-3 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {busy[upgradeType] ? '…' : 'Contribute'}
+                  </button>
+                </div>
+                {feedback[upgradeType] && (
+                  <p className="text-rose-400/90 text-[10px] font-mono mt-2">{feedback[upgradeType]}</p>
+                )}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+export const ComputerInterface = ({ onClose, onOpenAdminPanel, socket }: ComputerInterfaceProps) => {
+  const [activeTab, setActiveTab] = useState<Tab>('dashboard');
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'f' || e.key === 'F') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const tabs: { id: Tab; label: string; icon: React.ReactNode }[] = [
+    { id: 'dashboard', label: 'Dashboard', icon: <Monitor className="w-3.5 h-3.5" /> },
+    { id: 'upgrades', label: 'Upgrades', icon: <Settings className="w-3.5 h-3.5" /> },
+    { id: 'shop', label: 'Desk Shop', icon: <ShoppingBag className="w-3.5 h-3.5" /> },
+    { id: 'perks', label: 'Company Perks', icon: <Users className="w-3.5 h-3.5" /> },
+  ];
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black/80">
+      <div
+        className="bg-[#1a1a2e] border-4 border-[#333] rounded-lg shadow-2xl w-[720px] max-h-[88vh] flex flex-col"
+        style={{ boxShadow: '0 0 40px rgba(0,200,255,0.15), inset 0 0 60px rgba(0,0,0,0.5)' }}
+      >
+        {/* Scanline overlay */}
+        <div
+          className="absolute inset-0 pointer-events-none rounded-lg"
+          style={{ background: 'repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px)' }}
+        />
 
         {/* Title bar */}
-        <div className="flex items-center justify-between px-5 py-3 bg-[#0d0d1a] border-b border-[#00c8ff]/30">
+        <div className="flex items-center justify-between px-5 py-3 bg-[#0d0d1a] border-b border-[#00c8ff]/30 shrink-0">
           <div className="flex items-center gap-3">
             <div className="w-2 h-2 rounded-full bg-[#00c8ff] animate-pulse" />
             <span className="text-[#00c8ff] text-xs font-mono tracking-widest uppercase">
               Dunder Mifflin Paper Co. — Employee Portal
             </span>
           </div>
-          <div className="flex items-center gap-3">
-            <span className="text-[#00c8ff]/50 text-[10px] font-mono">
-              {time.toLocaleTimeString()}
-            </span>
-            <button onClick={onClose} className="text-[#00c8ff]/60 hover:text-red-400 transition-colors">
-              <X className="w-4 h-4" />
-            </button>
-          </div>
+          <button onClick={onClose} className="text-[#00c8ff]/60 hover:text-red-400 transition-colors">
+            <X className="w-4 h-4" />
+          </button>
         </div>
 
-        {/* Screen content */}
-        <div className="flex-1 overflow-y-auto p-6 flex flex-col gap-5 font-mono">
+        {/* Tab bar */}
+        <div className="flex border-b border-[#00c8ff]/20 bg-[#0d0d1a]/50 shrink-0">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex items-center gap-1.5 px-4 py-2.5 text-[10px] font-mono uppercase tracking-widest transition-colors ${
+                activeTab === tab.id
+                  ? 'text-[#00c8ff] border-b-2 border-[#00c8ff] bg-[#00c8ff]/5'
+                  : 'text-[#00c8ff]/40 hover:text-[#00c8ff]/70'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </div>
 
-          {/* Welcome banner */}
-          <div className="border border-[#00c8ff]/30 bg-[#00c8ff]/5 px-5 py-4 rounded">
-            <div className="text-[#00c8ff] text-sm mb-1">
-              Welcome back, <span className="text-white font-bold">{displayName}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Wifi className="w-3 h-3 text-emerald-400" />
-              <span className="text-emerald-400 text-[10px] tracking-widest uppercase">Connected — {roomId ?? 'Office'}</span>
-              {myRole && (
-                <span className={`ml-2 text-[9px] px-2 py-0.5 rounded border ${
-                  myRole === 'admin' ? 'border-amber-400/50 text-amber-400 bg-amber-400/10' :
-                  myRole === 'manager' ? 'border-indigo-400/50 text-indigo-400 bg-indigo-400/10' :
-                  'border-slate-400/50 text-slate-400 bg-slate-400/10'
-                } uppercase tracking-widest`}>
-                  {myRole}
-                </span>
-              )}
-            </div>
-          </div>
+        {/* Tab content */}
+        <div className="flex-1 overflow-y-auto p-6 font-mono">
+          {activeTab === 'dashboard' && <DashboardTab onClose={onClose} onOpenAdminPanel={onOpenAdminPanel} />}
+          {activeTab === 'upgrades' && <UpgradesTab socket={socket} />}
+          {activeTab === 'shop' && <DeskShopTab socket={socket} />}
+          {activeTab === 'perks' && <PerksTab socket={socket} />}
+        </div>
 
-          {/* Stats grid */}
-          <div className="grid grid-cols-2 gap-4">
-            <div className="border border-[#00c8ff]/20 bg-[#00c8ff]/5 p-4 rounded">
-              <div className="flex items-center gap-2 mb-3">
-                <FileText className="w-3.5 h-3.5 text-[#00c8ff]/60" />
-                <span className="text-[#00c8ff]/60 text-[9px] uppercase tracking-widest">Sales Performance</span>
-              </div>
-              <div className="text-3xl font-bold text-white">{paperReams.toLocaleString()}</div>
-              <div className="text-[#00c8ff]/40 text-[9px] mt-1 uppercase tracking-widest">Reams Sold</div>
-            </div>
-
-            <div className="border border-[#00c8ff]/20 bg-[#00c8ff]/5 p-4 rounded">
-              <div className="flex items-center gap-2 mb-3">
-                <Clock className="w-3.5 h-3.5 text-[#00c8ff]/60" />
-                <span className="text-[#00c8ff]/60 text-[9px] uppercase tracking-widest">Focus Session</span>
-              </div>
-              {isTimerActive ? (
-                <>
-                  <div className="text-3xl font-bold text-emerald-400">{formatTime(timeLeft)}</div>
-                  <div className="text-emerald-400/60 text-[9px] mt-1 uppercase tracking-widest">
-                    Active · +{sessionPaper} reams this session
-                  </div>
-                </>
-              ) : (
-                <>
-                  <div className="text-3xl font-bold text-[#00c8ff]/30">--:--</div>
-                  <div className="text-[#00c8ff]/30 text-[9px] mt-1 uppercase tracking-widest">No active session</div>
-                </>
-              )}
-            </div>
-          </div>
-
-          {/* Divider */}
-          <div className="border-t border-[#00c8ff]/10" />
-
-          {/* Admin section */}
-          {(myRole === 'admin' || myRole === 'manager') && (
-            <div className="border border-amber-400/30 bg-amber-400/5 p-4 rounded">
-              <div className="flex items-center gap-2 mb-3">
-                <Settings className="w-3.5 h-3.5 text-amber-400/70" />
-                <span className="text-amber-400/70 text-[9px] uppercase tracking-widest">Office Management</span>
-              </div>
-              <p className="text-[#00c8ff]/50 text-[10px] mb-4 leading-relaxed">
-                Manage office members, assign roles, and configure workspace settings.
-              </p>
-              <button
-                onClick={() => { onClose(); onOpenAdminPanel(); }}
-                className="flex items-center gap-2 px-4 py-2.5 bg-amber-400/20 hover:bg-amber-400/30 border border-amber-400/40 text-amber-300 text-[10px] uppercase tracking-widest rounded transition-all"
-              >
-                <Settings className="w-3 h-3" />
-                Manage Office
-              </button>
-            </div>
-          )}
-
-          {/* Footer hint */}
-          <div className="text-[#00c8ff]/20 text-[9px] text-center uppercase tracking-widest mt-auto">
-            Press [F] or [Esc] to close
-          </div>
+        {/* Footer */}
+        <div className="text-[#00c8ff]/20 text-[9px] text-center uppercase tracking-widest py-2 border-t border-[#00c8ff]/10 shrink-0">
+          Press [F] or [Esc] to close
         </div>
       </div>
     </div>

--- a/src/components/ui/VendingMenu.tsx
+++ b/src/components/ui/VendingMenu.tsx
@@ -3,69 +3,20 @@ import { ArrowLeft, X } from 'lucide-react';
 import type { Socket } from 'socket.io-client';
 import { useGameStore } from '../../store/useGameStore';
 import { ICE_CREAM_FLAVORS, ICE_CREAM_FLAVOR_COUNT } from '../../iceCreamFlavors';
-import { ICE_CREAM_QUARTERS_MAX } from '../../gameConfig';
-import {
-  CHAIR_UPGRADE_COST_REAMS,
-  CHAIR_UPGRADE_MAX_LEVEL,
-} from '../../chairUpgradeConstants';
-import {
-  MONITOR_UPGRADE_MAX_LEVEL,
-  monitorUpgradeCostForNextLevel,
-} from '../../monitorUpgradeConstants';
-import {
-  FOCUS_ENERGY_SEATED_REGEN_MAX_PER_MIN,
-  FOCUS_ENERGY_SEATED_REGEN_PER_CHAIR_LEVEL_PER_MIN,
-} from '../../focusEnergyModel';
-
-import {
-  ICE_CREAM_COST_REAMS,
-  ICE_CREAM_DURATION_MS,
-  TEAM_PYRAMID_COST_REAMS,
-} from '../../gameConfig';
+import { ICE_CREAM_QUARTERS_MAX, ICE_CREAM_COST_REAMS, ICE_CREAM_DURATION_MS } from '../../gameConfig';
 
 interface VendingMenuProps {
   onClose: () => void;
   socket: Socket | null;
 }
 
-type ChairPurchaseAck =
-  | { ok: true; paperReams: number; chairUpgradeLevel: number }
-  | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
-
-type MonitorPurchaseAck =
-  | { ok: true; paperReams: number; monitorUpgradeLevel: number }
-  | { ok: false; error: 'max_level' | 'insufficient' | 'not_in_room' | 'server_error' };
-
-type TeamPyramidPurchaseAck =
-  | { ok: true; paperReams: number; expiresAt: number }
-  | { ok: false; error: 'insufficient' | 'not_in_room' | 'server_error' };
-
 export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const paperReams = useGameStore((s) => s.paperReams);
   const addPaper = useGameStore((s) => s.addPaper);
   const setHeldIceCream = useGameStore((s) => s.setHeldIceCream);
-  const user = useGameStore((s) => s.user);
-  const chairLevelByEmail = useGameStore((s) => s.chairLevelByEmail);
-  const setPaperReams = useGameStore((s) => s.setPaperReams);
-  const patchChairLevel = useGameStore((s) => s.patchChairLevel);
-  const monitorLevelByEmail = useGameStore((s) => s.monitorLevelByEmail);
-  const patchMonitorLevel = useGameStore((s) => s.patchMonitorLevel);
-  const setTeamPyramidBuffExpiresAt = useGameStore((s) => s.setTeamPyramidBuffExpiresAt);
   const [subView, setSubView] = useState<'main' | 'flavor'>('main');
   const [selectedFlavor, setSelectedFlavor] = useState(0);
   const [feedback, setFeedback] = useState<'insufficient' | 'offline' | null>(null);
-  const [chairBusy, setChairBusy] = useState(false);
-  const [chairFeedback, setChairFeedback] = useState<
-    'insufficient' | 'max_level' | 'offline' | 'not_in_room' | 'server_error' | null
-  >(null);
-  const [monitorBusy, setMonitorBusy] = useState(false);
-  const [monitorFeedback, setMonitorFeedback] = useState<
-    'insufficient' | 'max_level' | 'offline' | 'not_in_room' | 'server_error' | null
-  >(null);
-  const [pyramidBusy, setPyramidBusy] = useState(false);
-  const [pyramidFeedback, setPyramidFeedback] = useState<
-    'insufficient' | 'offline' | 'not_in_room' | 'server_error' | null
-  >(null);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -85,30 +36,14 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
   const canAfford = paperReams >= ICE_CREAM_COST_REAMS;
   const socketOk = socket?.connected === true;
 
-  const myChairLevel = user?.email ? (chairLevelByEmail[user.email] ?? 0) : 0;
-  const chairMaxed = myChairLevel >= CHAIR_UPGRADE_MAX_LEVEL;
-  const canAffordChair = paperReams >= CHAIR_UPGRADE_COST_REAMS;
-
-  const myMonitorLevel = user?.email ? (monitorLevelByEmail[user.email] ?? 0) : 0;
-  const monitorMaxed = myMonitorLevel >= MONITOR_UPGRADE_MAX_LEVEL;
-  const nextMonitorCost = monitorMaxed ? 0 : monitorUpgradeCostForNextLevel(myMonitorLevel);
-  const canAffordMonitor = !monitorMaxed && paperReams >= nextMonitorCost;
-  const canAffordPyramid = paperReams >= TEAM_PYRAMID_COST_REAMS;
-
   const openFlavorSubmenu = () => {
     setFeedback(null);
     setSubView('flavor');
   };
 
   const handleConfirmBuy = () => {
-    if (!canAfford) {
-      setFeedback('insufficient');
-      return;
-    }
-    if (!socket?.connected) {
-      setFeedback('offline');
-      return;
-    }
+    if (!canAfford) { setFeedback('insufficient'); return; }
+    if (!socket?.connected) { setFeedback('offline'); return; }
     const flavorIndex = Math.min(Math.max(0, selectedFlavor), ICE_CREAM_FLAVOR_COUNT - 1);
     const expiresAt = Date.now() + ICE_CREAM_DURATION_MS;
     addPaper(-ICE_CREAM_COST_REAMS);
@@ -122,119 +57,6 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
     onClose();
   };
 
-  const handleBuyChairUpgrade = () => {
-    setChairFeedback(null);
-    if (!socket?.connected) {
-      setChairFeedback('offline');
-      return;
-    }
-    if (chairMaxed) {
-      setChairFeedback('max_level');
-      return;
-    }
-    if (!canAffordChair) {
-      setChairFeedback('insufficient');
-      return;
-    }
-    setChairBusy(true);
-    socket.timeout(12_000).emit('purchaseChairUpgrade', (socketErr: Error | null, res: unknown) => {
-      setChairBusy(false);
-      if (socketErr) {
-        setChairFeedback('server_error');
-        return;
-      }
-      const r = res as ChairPurchaseAck;
-      if (!r || typeof r !== 'object' || !('ok' in r)) {
-        setChairFeedback('server_error');
-        return;
-      }
-      if (r.ok === true) {
-        setPaperReams(r.paperReams);
-        if (user?.email) patchChairLevel(user.email, r.chairUpgradeLevel);
-        return;
-      }
-      const fail = r.error;
-      if (fail === 'max_level') setChairFeedback('max_level');
-      else if (fail === 'insufficient') setChairFeedback('insufficient');
-      else if (fail === 'not_in_room') setChairFeedback('not_in_room');
-      else setChairFeedback('server_error');
-    });
-  };
-
-  const handleBuyMonitorUpgrade = () => {
-    setMonitorFeedback(null);
-    if (!socket?.connected) {
-      setMonitorFeedback('offline');
-      return;
-    }
-    if (monitorMaxed) {
-      setMonitorFeedback('max_level');
-      return;
-    }
-    if (!canAffordMonitor) {
-      setMonitorFeedback('insufficient');
-      return;
-    }
-    setMonitorBusy(true);
-    socket.timeout(12_000).emit('purchaseMonitorUpgrade', (socketErr: Error | null, res: unknown) => {
-      setMonitorBusy(false);
-      if (socketErr) {
-        setMonitorFeedback('server_error');
-        return;
-      }
-      const r = res as MonitorPurchaseAck;
-      if (!r || typeof r !== 'object' || !('ok' in r)) {
-        setMonitorFeedback('server_error');
-        return;
-      }
-      if (r.ok === true) {
-        setPaperReams(r.paperReams);
-        if (user?.email) patchMonitorLevel(user.email, r.monitorUpgradeLevel);
-        return;
-      }
-      const fail = r.error;
-      if (fail === 'max_level') setMonitorFeedback('max_level');
-      else if (fail === 'insufficient') setMonitorFeedback('insufficient');
-      else if (fail === 'not_in_room') setMonitorFeedback('not_in_room');
-      else setMonitorFeedback('server_error');
-    });
-  };
-
-  const handleBuyTeamPyramid = () => {
-    setPyramidFeedback(null);
-    if (!socket?.connected) {
-      setPyramidFeedback('offline');
-      return;
-    }
-    if (!canAffordPyramid) {
-      setPyramidFeedback('insufficient');
-      return;
-    }
-    setPyramidBusy(true);
-    socket.timeout(12_000).emit('purchaseTeamPyramid', (socketErr: Error | null, res: unknown) => {
-      setPyramidBusy(false);
-      if (socketErr) {
-        setPyramidFeedback('server_error');
-        return;
-      }
-      const r = res as TeamPyramidPurchaseAck;
-      if (!r || typeof r !== 'object' || !('ok' in r)) {
-        setPyramidFeedback('server_error');
-        return;
-      }
-      if (r.ok === true) {
-        setPaperReams(r.paperReams);
-        setTeamPyramidBuffExpiresAt(r.expiresAt);
-        onClose();
-        return;
-      }
-      const fail = r.error;
-      if (fail === 'insufficient') setPyramidFeedback('insufficient');
-      else if (fail === 'not_in_room') setPyramidFeedback('not_in_room');
-      else setPyramidFeedback('server_error');
-    });
-  };
-
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4"
@@ -243,7 +65,7 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
       aria-labelledby="vending-title"
     >
       <div
-        className="relative w-full max-w-5xl bg-slate-900 border-4 border-black pixel-border p-4 sm:p-6 shadow-2xl max-h-[92vh] flex flex-col"
+        className="relative w-full max-w-sm bg-slate-900 border-4 border-black pixel-border p-4 sm:p-6 shadow-2xl max-h-[92vh] flex flex-col"
         style={{ boxShadow: '8px 8px 0 0 #1e1b4b' }}
       >
         <div className="flex items-start justify-between gap-3 pr-1 shrink-0">
@@ -292,152 +114,18 @@ export const VendingMenu = ({ onClose, socket }: VendingMenuProps) => {
                   </p>
                 </div>
               </div>
-
-              <div className="border-2 border-fuchsia-600/45 bg-fuchsia-950/30 p-3">
-                <div className="grid grid-cols-[auto_minmax(92px,150px)_1fr] gap-3 items-start">
-                  <button
-                    type="button"
-                    onClick={handleBuyTeamPyramid}
-                    disabled={!socketOk || pyramidBusy}
-                    className="pixel-button font-pixel text-[8px] sm:text-[10px] text-center min-w-[94px] disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {pyramidBusy ? 'Wait' : 'Buy'}
-                  </button>
-                  <p className="font-pixel text-[8px] sm:text-[10px] text-fuchsia-100 pt-1">🔺 Team Pyramid</p>
-                  <p className="text-slate-400 text-[10px] sm:text-xs font-mono leading-snug pt-1">
-                    Team buff: +50% paper for 3 hours while focusing. Cost: {TEAM_PYRAMID_COST_REAMS} reams.
-                  </p>
-                </div>
-                {pyramidFeedback === 'insufficient' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">Not enough reams.</p>
-                )}
-                {pyramidFeedback === 'not_in_room' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">Join the office room first.</p>
-                )}
-                {pyramidFeedback === 'server_error' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">
-                    Could not complete purchase - try again.
-                  </p>
-                )}
-                {pyramidFeedback === 'offline' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">
-                    Not connected - try again when online.
-                  </p>
-                )}
-              </div>
-
-              <div className="border-2 border-amber-600/40 bg-amber-950/25 p-3">
-                <div className="grid grid-cols-[auto_minmax(92px,150px)_1fr] gap-3 items-start">
-                  <button
-                    type="button"
-                    onClick={handleBuyChairUpgrade}
-                    disabled={!socketOk || chairMaxed || chairBusy}
-                    className="pixel-button font-pixel text-[8px] sm:text-[10px] text-center min-w-[94px] disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {chairMaxed ? 'Maxed' : chairBusy ? 'Wait' : 'Buy'}
-                  </button>
-                  <p className="font-pixel text-[8px] sm:text-[10px] text-amber-100 pt-1">🪑 Chair Upgrade</p>
-                  <div className="text-slate-400 text-[10px] sm:text-xs font-mono leading-snug pt-1">
-                    Bigger seat and desk style upgrades that everyone can see. Cost:{' '}
-                    {CHAIR_UPGRADE_COST_REAMS} reams.
-                    <p className="text-slate-500 text-[9px] sm:text-[10px] mt-1">
-                      Seated focus: +{FOCUS_ENERGY_SEATED_REGEN_PER_CHAIR_LEVEL_PER_MIN} energy/min each level
-                      (max +{FOCUS_ENERGY_SEATED_REGEN_MAX_PER_MIN}/min).
-                    </p>
-                    <p className="text-slate-500 text-[9px] sm:text-[10px] mt-1">
-                      Your level:{' '}
-                      <span className="text-amber-200">
-                        {myChairLevel}/{CHAIR_UPGRADE_MAX_LEVEL}
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                {!socketOk && (
-                  <p className="text-amber-400/90 text-[10px] font-mono mt-2">Connect to purchase upgrades.</p>
-                )}
-                {chairFeedback === 'insufficient' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">Not enough reams.</p>
-                )}
-                {chairFeedback === 'max_level' && (
-                  <p className="text-slate-400 text-xs font-mono mt-2">
-                    Already at max level ({CHAIR_UPGRADE_MAX_LEVEL}).
-                  </p>
-                )}
-                {chairFeedback === 'not_in_room' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">Join the office room first.</p>
-                )}
-                {chairFeedback === 'server_error' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">
-                    Could not complete purchase - try again.
-                  </p>
-                )}
-                {chairFeedback === 'offline' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">
-                    Not connected - try again when online.
-                  </p>
-                )}
-              </div>
-
-              <div className="border-2 border-cyan-700/40 bg-cyan-950/20 p-3">
-                <div className="grid grid-cols-[auto_minmax(92px,150px)_1fr] gap-3 items-start">
-                  <button
-                    type="button"
-                    onClick={handleBuyMonitorUpgrade}
-                    disabled={!socketOk || monitorMaxed || monitorBusy}
-                    className="pixel-button font-pixel text-[8px] sm:text-[10px] text-center min-w-[94px] disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {monitorMaxed ? 'Maxed' : monitorBusy ? 'Wait' : 'Buy'}
-                  </button>
-                  <p className="font-pixel text-[8px] sm:text-[10px] text-cyan-100 pt-1">🖥️ Desk Monitors</p>
-                  <div className="text-slate-400 text-[10px] sm:text-xs font-mono leading-snug pt-1">
-                    Add screens to your desk (up to 8). First 3 upgrades add +1 ream/min while focusing.
-                    {!monitorMaxed && (
-                      <p className="text-slate-500 text-[9px] sm:text-[10px] mt-1">
-                        Next upgrade costs {nextMonitorCost} reams.
-                      </p>
-                    )}
-                    <p className="text-slate-500 text-[9px] sm:text-[10px] mt-1">
-                      Upgrades:{' '}
-                      <span className="text-cyan-200">
-                        {myMonitorLevel}/{MONITOR_UPGRADE_MAX_LEVEL}
-                      </span>
-                    </p>
-                  </div>
-                </div>
-                {monitorFeedback === 'insufficient' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">Not enough reams.</p>
-                )}
-                {monitorFeedback === 'max_level' && (
-                  <p className="text-slate-400 text-xs font-mono mt-2">
-                    Already at max ({MONITOR_UPGRADE_MAX_LEVEL} upgrades, 8 monitors).
-                  </p>
-                )}
-                {monitorFeedback === 'not_in_room' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">Join the office room first.</p>
-                )}
-                {monitorFeedback === 'server_error' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">
-                    Could not complete purchase - try again.
-                  </p>
-                )}
-                {monitorFeedback === 'offline' && (
-                  <p className="text-rose-400/90 text-xs font-mono mt-2">
-                    Not connected - try again when online.
-                  </p>
-                )}
-              </div>
             </div>
 
-            <p className="mt-4 text-center text-slate-500 font-mono text-[10px] shrink-0">Press Esc to close</p>
+            <p className="mt-3 text-center text-slate-500 font-mono text-[10px]">
+              For desk upgrades, press [F] at your desk.
+            </p>
+            <p className="mt-2 text-center text-slate-500 font-mono text-[10px] shrink-0">Press Esc to close</p>
           </>
         ) : (
           <div className="mt-4 overflow-y-auto pr-1 flex-1 min-h-0" style={{ scrollbarGutter: 'stable' }}>
             <button
               type="button"
-              onClick={() => {
-                setSubView('main');
-                setFeedback(null);
-              }}
+              onClick={() => { setSubView('main'); setFeedback(null); }}
               className="flex items-center gap-1.5 text-violet-300 hover:text-white font-mono text-[10px] mb-4"
             >
               <ArrowLeft className="w-3.5 h-3.5" />

--- a/src/components/world/working-area/Desk.tsx
+++ b/src/components/world/working-area/Desk.tsx
@@ -5,6 +5,7 @@ import { MONITOR_UPGRADE_MAX_LEVEL } from '../../../monitorUpgradeConstants';
 import { useGameStore } from '../../../store/useGameStore';
 import { Chair } from '../shared/props/Chair';
 import { onOverlayTextSync } from '../../../utils/overlayTextSync';
+import type { DeskItemPlacement } from '../../../types';
 
 // Shared materials — avoids creating hundreds of duplicate instances
 const monitorBodyMat = new THREE.MeshStandardMaterial({ color: '#111111' });
@@ -85,6 +86,41 @@ function DeskMonitors({ count }: { count: number }) {
         });
       })}
     </group>
+  );
+}
+
+/** Simple Dundie trophy rendered on the desk surface. */
+function DundieAward({ x, z }: { x: number; z: number }) {
+  return (
+    <group position={[x, 1.05, z]}>
+      {/* Cup */}
+      <Cylinder args={[0.04, 0.03, 0.1, 8]} position={[0, 0.1, 0]}>
+        <meshStandardMaterial color="#FFD700" metalness={0.7} roughness={0.3} />
+      </Cylinder>
+      {/* Stem */}
+      <Cylinder args={[0.015, 0.015, 0.08, 8]} position={[0, 0.04, 0]}>
+        <meshStandardMaterial color="#b8860b" metalness={0.6} roughness={0.4} />
+      </Cylinder>
+      {/* Base */}
+      <Cylinder args={[0.055, 0.055, 0.025, 8]} position={[0, 0, 0]}>
+        <meshStandardMaterial color="#b8860b" metalness={0.6} roughness={0.3} />
+      </Cylinder>
+    </group>
+  );
+}
+
+function DeskDecorations({ ownerEmail }: { ownerEmail?: string }) {
+  const deskItemsByEmail = useGameStore((s) => s.deskItemsByEmail);
+  if (!ownerEmail) return null;
+  const items: DeskItemPlacement[] = deskItemsByEmail[ownerEmail] ?? [];
+  if (items.length === 0) return null;
+  return (
+    <>
+      {items.map((item) => {
+        if (item.id === 'dundie') return <DundieAward key={item.id} x={item.x} z={item.z} />;
+        return null;
+      })}
+    </>
   );
 }
 
@@ -201,6 +237,8 @@ export const Desk = ({
       <Box args={[0.5, 0.02, 0.15]} position={[0, 1.01, 0.25]} material={deskKeyboardMat} />
 
       <DeskMonitors count={monitorCount} />
+
+      <DeskDecorations ownerEmail={ownerEmail} />
 
       {hasChair && (
         <Chair position={[0, 0, 0.8]} rotation={[0, Math.PI, 0]} level={chairLevel} />

--- a/src/deskItemCatalog.ts
+++ b/src/deskItemCatalog.ts
@@ -1,0 +1,15 @@
+export interface DeskItemDef {
+  id: string;
+  name: string;
+  description: string;
+  cost: number;
+}
+
+export const DESK_ITEM_CATALOG: DeskItemDef[] = [
+  {
+    id: 'dundie',
+    name: 'Dundie Award',
+    description: '"Best Employee" — a golden Dundie trophy recognizing your dedication.',
+    cost: 500,
+  },
+];

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -235,22 +235,25 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       }
     });
 
-    const applyTeamPyramidBuff = (payload: { expiresAt?: unknown }) => {
-      const raw = payload?.expiresAt;
-      if (raw == null) {
-        useGameStore.getState().setTeamPyramidBuffExpiresAt(null);
-        return;
-      }
-      const n = typeof raw === 'number' ? raw : Number(raw);
-      if (!Number.isFinite(n) || Date.now() >= n) {
-        useGameStore.getState().setTeamPyramidBuffExpiresAt(null);
-        return;
-      }
-      useGameStore.getState().setTeamPyramidBuffExpiresAt(n);
-    };
+    newSocket.on('deskItemsLoaded', (map: Record<string, unknown[]>) => {
+      if (map && typeof map === 'object') useGameStore.getState().setDeskItemsByEmail(map as Record<string, import('../types').DeskItemPlacement[]>);
+    });
 
-    newSocket.on('teamPyramidBuffLoaded', applyTeamPyramidBuff);
-    newSocket.on('teamPyramidBuffUpdated', applyTeamPyramidBuff);
+    newSocket.on('deskItemUpdated', (payload: { email: string; items: import('../types').DeskItemPlacement[] }) => {
+      if (payload?.email && Array.isArray(payload.items)) {
+        useGameStore.getState().patchDeskItems(payload.email, payload.items);
+      }
+    });
+
+    newSocket.on('teamUpgradePoolsLoaded', (pools: Record<string, import('../types').TeamUpgradePool>) => {
+      if (pools && typeof pools === 'object') useGameStore.getState().setTeamUpgradePools(pools);
+    });
+
+    newSocket.on('teamUpgradePoolUpdated', (payload: { upgradeType: string; pool: import('../types').TeamUpgradePool }) => {
+      if (payload?.upgradeType && payload.pool) {
+        useGameStore.getState().patchTeamUpgradePool(payload.upgradeType, payload.pool);
+      }
+    });
 
     newSocket.on('roomInfoLoaded', (info: RoomInfo) => {
       console.log(`[socket] roomInfoLoaded: role=${info.myRole ?? 'visitor'} members=${info.memberCount}`);
@@ -329,6 +332,8 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       unsubscribeReams();
       useGameStore.getState().resetChairLevels();
       useGameStore.getState().resetMonitorLevels();
+      useGameStore.getState().resetDeskItems();
+      useGameStore.getState().setTeamUpgradePools({});
       useGameStore.getState().setRoomInfo(null);
       useGameStore.getState().setRemoteWornThrowableIds([]);
       useGameStore.getState().clearWornProp();

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -15,7 +15,7 @@ import {
   TEAM_PYRAMID_FOCUS_REAM_MULTIPLIER,
 } from '../gameConfig';
 import { getEffectiveDeskUpgradeEmail } from '../deskOwner';
-import { AvatarConfig, DEFAULT_AVATAR_CONFIG, FurnitureItem, RoomInfo } from '../types';
+import { AvatarConfig, DEFAULT_AVATAR_CONFIG, DeskItemPlacement, FurnitureItem, RoomInfo, TeamUpgradePool } from '../types';
 
 export type InspectPreviewKind = 'model' | 'pyramid';
 
@@ -121,6 +121,15 @@ interface GameState {
   setDeskMonitorLevels: (map: Record<string, number>) => void;
   patchMonitorLevel: (email: string, level: number) => void;
   resetMonitorLevels: () => void;
+  /** Desk owner email → purchased desk decoration placements; synced from server. */
+  deskItemsByEmail: Record<string, DeskItemPlacement[]>;
+  setDeskItemsByEmail: (map: Record<string, DeskItemPlacement[]>) => void;
+  patchDeskItems: (email: string, items: DeskItemPlacement[]) => void;
+  resetDeskItems: () => void;
+  /** upgradeType → contribution pool state; synced from server. */
+  teamUpgradePools: Record<string, TeamUpgradePool>;
+  setTeamUpgradePools: (pools: Record<string, TeamUpgradePool>) => void;
+  patchTeamUpgradePool: (upgradeType: string, pool: TeamUpgradePool) => void;
   roomInfo: RoomInfo | null;
   setRoomInfo: (info: RoomInfo | null) => void;
 
@@ -454,6 +463,23 @@ export const useGameStore = create<GameState>((set, get) => ({
       monitorLevelByEmail: { ...s.monitorLevelByEmail, [email]: level },
     })),
   resetMonitorLevels: () => set({ monitorLevelByEmail: {} }),
+  deskItemsByEmail: {},
+  setDeskItemsByEmail: (map) =>
+    set((s) => ({ deskItemsByEmail: { ...s.deskItemsByEmail, ...map } })),
+  patchDeskItems: (email, items) =>
+    set((s) => ({ deskItemsByEmail: { ...s.deskItemsByEmail, [email]: items } })),
+  resetDeskItems: () => set({ deskItemsByEmail: {} }),
+  teamUpgradePools: {},
+  setTeamUpgradePools: (pools) => set({
+    teamUpgradePools: pools,
+    // Keep backward-compat field in sync
+    teamPyramidBuffExpiresAt: pools['pyramid']?.expiresAt ?? null,
+  }),
+  patchTeamUpgradePool: (upgradeType, pool) =>
+    set((s) => ({
+      teamUpgradePools: { ...s.teamUpgradePools, [upgradeType]: pool },
+      ...(upgradeType === 'pyramid' ? { teamPyramidBuffExpiresAt: pool.expiresAt } : {}),
+    })),
   roomInfo: null,
   setRoomInfo: (info) => set({ roomInfo: info }),
 

--- a/src/teamUpgradeDefs.ts
+++ b/src/teamUpgradeDefs.ts
@@ -1,0 +1,18 @@
+import { TEAM_PYRAMID_COST_REAMS, TEAM_PYRAMID_DURATION_MS } from './gameConfig';
+
+export interface TeamUpgradeDef {
+  target: number;
+  durationMs: number;
+  displayName: string;
+  description: string;
+}
+
+export const TEAM_UPGRADE_DEFS: Record<string, TeamUpgradeDef> = {
+  pyramid: {
+    target: TEAM_PYRAMID_COST_REAMS,
+    durationMs: TEAM_PYRAMID_DURATION_MS,
+    displayName: 'Team Pyramid',
+    description:
+      'Team-wide buff: 3 hours of +50% paper reams for everyone while focusing. Pool reams together to activate — anyone can contribute any amount. Unleash the power of the pyramid!',
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,28 @@ export interface DeskItem extends FurnitureItem {
   config: { ownerEmail: string; ownerName: string; model?: string; [key: string]: unknown };
 }
 
+/** A purchased desk decoration item placed at a specific position on the desk surface. */
+export interface DeskItemPlacement {
+  /** Catalog item id (e.g. 'dundie'). */
+  id: string;
+  /** Local desk X offset (-1..1). */
+  x: number;
+  /** Local desk Z offset (-0.4..0.4). */
+  z: number;
+}
+
+/** In-memory state of a team upgrade contribution pool. */
+export interface TeamUpgradePool {
+  /** Total reams contributed so far this cycle. */
+  contributed: number;
+  /** Reams required to activate the upgrade. */
+  target: number;
+  /** email → amount contributed */
+  contributors: Record<string, number>;
+  /** Wall-clock ms when the active buff expires; null if not yet activated. */
+  expiresAt: number | null;
+}
+
 /** Describes a room's footprint for the 2D floor-plan editor.
  *  Export one of these as `FLOOR_PLAN_RECT` from each room component so the
  *  customization page automatically stays in sync with the 3D layout. */


### PR DESCRIPTION
## Summary

- Moves chair/monitor upgrades and Team Pyramid from the vending machine to the desk computer (`[F]` key), organized into 4 tabs: **Dashboard**, **Upgrades**, **Desk Shop**, **Company Perks**
- Adds **Desk Decorations** — purchase a Dundie Award (500 reams) and drag-rearrange items on a top-down SVG desk view; persisted per-user in DB and rendered as a 3D trophy on the desk
- Replaces the single-payer Team Pyramid with a **team contribution pool** — any player can chip in any amount toward the shared target; progress bar + contributor list visible to all room members
- Vending machine now serves **ice cream only**; hints players to use the desk computer for upgrades

## Test plan

- [ ] Press `F` at own desk — computer opens with 4 tabs
- [ ] **Upgrades tab**: buy chair upgrade → chair visually updates, balance deducts
- [ ] **Upgrades tab**: buy monitor upgrade → monitor count increases
- [ ] **Desk Shop tab**: buy Dundie Award → item appears on desk; drag it in SVG view → position persists after reload
- [ ] **Company Perks tab**: contribute partial reams toward Team Pyramid → progress bar updates; contribute remainder → buff activates
- [ ] Open second browser tab in same room → desk items, upgrade levels, and team upgrade pool all sync
- [ ] Open vending machine → only ice cream remains, shows "For desk upgrades, press [F] at your desk" hint
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)