### PR TITLE
Fix chat input not accepting space characters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,7 +96,12 @@ export default function App() {
 
   useEffect(() => {
     const preventSpaceScroll = (e: KeyboardEvent) => {
-      if (e.code === 'Space') e.preventDefault();
+      const target = e.target as HTMLElement | null;
+      const isTypingTarget =
+        target?.tagName === 'INPUT' ||
+        target?.tagName === 'TEXTAREA' ||
+        target?.isContentEditable;
+      if (e.code === 'Space' && !isTypingTarget) e.preventDefault();
     };
     window.addEventListener('keydown', preventSpaceScroll);
     return () => window.removeEventListener('keydown', preventSpaceScroll);


### PR DESCRIPTION
### Motivation
- The app globally suppressed the `Space` key to prevent page scrolling, which inadvertently blocked typing spaces in chat input and other editable fields.
- The intended behavior is to keep preventing page scroll when not typing while allowing normal space input when focus is inside text-entry targets.

### Description
- Updated `src/App.tsx` to scope the global spacebar handler so it only calls `preventDefault()` when the event target is not a typing target.
- The handler now checks the event target's `tagName` and `isContentEditable` (casting `e.target` to `HTMLElement`) and skips `preventDefault()` for `input`, `textarea`, or `contentEditable` elements.
- This preserves the existing behavior of stopping page scroll on `Space` outside of typing contexts while restoring space input in chat.

### Testing
- Ran `npm run lint` which executes `tsc --noEmit`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd91ca61208328af5453785299cabf)