### PR TITLE
Add admin-controlled "New Employee" auto-join mode

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -112,8 +112,12 @@ async function initDb() {
     CREATE TABLE IF NOT EXISTS rooms (
       room_id     TEXT PRIMARY KEY,
       max_workers INTEGER NOT NULL DEFAULT 20,
+      allow_new_employees BOOLEAN NOT NULL DEFAULT FALSE,
       created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
     )
+  `);
+  await pool!.query(`
+    ALTER TABLE rooms ADD COLUMN IF NOT EXISTS allow_new_employees BOOLEAN NOT NULL DEFAULT FALSE
   `);
   await pool!.query(`
     CREATE TABLE IF NOT EXISTS room_members (
@@ -931,6 +935,15 @@ async function getRoomMaxWorkers(roomId: string): Promise<number> {
   return rows[0]?.max_workers ?? 20;
 }
 
+async function getRoomAllowNewEmployees(roomId: string): Promise<boolean> {
+  if (isLocalTest()) return mem.memGetRoomAllowNewEmployees(roomId);
+  const { rows } = await pool!.query(
+    "SELECT allow_new_employees FROM rooms WHERE room_id = $1",
+    [roomId]
+  );
+  return Boolean(rows[0]?.allow_new_employees);
+}
+
 async function getRoomMemberCount(roomId: string): Promise<number> {
   if (isLocalTest()) return mem.memGetRoomMemberCount(roomId);
   const { rows } = await pool!.query(
@@ -1002,6 +1015,14 @@ async function updateRoomMaxWorkers(roomId: string, maxWorkers: number): Promise
   if (isLocalTest()) return mem.memUpdateRoomMaxWorkers(roomId, maxWorkers);
   await pool!.query("UPDATE rooms SET max_workers = $1 WHERE room_id = $2", [
     maxWorkers,
+    roomId,
+  ]);
+}
+
+async function updateRoomAllowNewEmployees(roomId: string, allowNewEmployees: boolean): Promise<void> {
+  if (isLocalTest()) return mem.memUpdateRoomAllowNewEmployees(roomId, allowNewEmployees);
+  await pool!.query("UPDATE rooms SET allow_new_employees = $1 WHERE room_id = $2", [
+    allowNewEmployees,
     roomId,
   ]);
 }
@@ -1319,17 +1340,34 @@ export async function createApp(injectedPool?: pg.Pool) {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
     const { roomId } = req.params;
-    const { maxWorkers } = req.body ?? {};
+    const { maxWorkers, allowNewEmployees } = req.body ?? {};
     try {
       const requesterRole = await getMemberRole(roomId, user.email);
       if (requesterRole !== 'admin') {
         return res.status(403).json({ error: "Forbidden" });
       }
-      if (typeof maxWorkers !== 'number' || maxWorkers < 1 || maxWorkers > 100) {
+      const hasMaxWorkers = maxWorkers !== undefined;
+      const hasAllowNewEmployees = allowNewEmployees !== undefined;
+      if (!hasMaxWorkers && !hasAllowNewEmployees) {
+        return res.status(400).json({ error: "Nothing to update" });
+      }
+      if (hasMaxWorkers && (typeof maxWorkers !== 'number' || maxWorkers < 1 || maxWorkers > 100)) {
         return res.status(400).json({ error: "maxWorkers must be 1-100" });
       }
-      await updateRoomMaxWorkers(roomId, maxWorkers);
-      io.to(roomId).emit("roomMembersUpdated", { roomId, maxWorkers });
+      if (hasAllowNewEmployees && typeof allowNewEmployees !== 'boolean') {
+        return res.status(400).json({ error: "allowNewEmployees must be boolean" });
+      }
+      if (hasMaxWorkers) {
+        await updateRoomMaxWorkers(roomId, maxWorkers);
+      }
+      if (hasAllowNewEmployees) {
+        await updateRoomAllowNewEmployees(roomId, allowNewEmployees);
+      }
+      io.to(roomId).emit("roomMembersUpdated", {
+        roomId,
+        ...(hasMaxWorkers ? { maxWorkers } : {}),
+        ...(hasAllowNewEmployees ? { allowNewEmployees } : {}),
+      });
       res.json({ ok: true });
     } catch {
       res.status(500).json({ error: "Internal server error" });
@@ -1462,7 +1500,19 @@ io.on("connection", (socket) => {
         await upsertMember(room, user.email, 'admin');
       }
 
-      const role = await getMemberRole(room, user.email);
+      let role = await getMemberRole(room, user.email);
+      const allowNewEmployees = await getRoomAllowNewEmployees(room);
+      if (role === null && allowNewEmployees) {
+        const [currentCount, maxWorkers] = await Promise.all([
+          getRoomMemberCount(room),
+          getRoomMaxWorkers(room),
+        ]);
+        if (currentCount < maxWorkers) {
+          await ensureUserRow(user.email);
+          await upsertMember(room, user.email, 'worker');
+          role = 'worker';
+        }
+      }
       const isMember = role !== null;
 
       // Initialize player using DB display name when set
@@ -1554,12 +1604,14 @@ io.on("connection", (socket) => {
           getRoomMembers(room),
           getRoomMaxWorkers(room),
         ]);
+        const allowNewEmployees = await getRoomAllowNewEmployees(room);
         const onlineEmails = new Set(
           Object.values(rooms[room]).map((p: any) => p.email)
         );
         socket.emit("roomInfoLoaded", {
           roomId: room,
           maxWorkers,
+          allowNewEmployees,
           myRole: role,
           memberCount: members.length,
           members: members.map(m => ({ ...m, isOnline: onlineEmails.has(m.email) }))

--- a/server/memoryDb.ts
+++ b/server/memoryDb.ts
@@ -50,6 +50,7 @@ interface UserRow {
 
 interface RoomRow {
   max_workers: number;
+  allow_new_employees: boolean;
   created_at: Date;
 }
 
@@ -128,7 +129,7 @@ export async function memSaveRoomLayout(roomId: string, layout: FurnitureItem[])
 
 export async function memEnsureRoom(roomId: string): Promise<boolean> {
   if (rooms.has(roomId)) return false;
-  rooms.set(roomId, { max_workers: 20, created_at: new Date() });
+  rooms.set(roomId, { max_workers: 20, allow_new_employees: false, created_at: new Date() });
   return true;
 }
 
@@ -231,6 +232,10 @@ export async function memGetMyRooms(
 
 export async function memGetRoomMaxWorkers(roomId: string): Promise<number> {
   return rooms.get(roomId)?.max_workers ?? 20;
+}
+
+export async function memGetRoomAllowNewEmployees(roomId: string): Promise<boolean> {
+  return rooms.get(roomId)?.allow_new_employees ?? false;
 }
 
 export async function memGetRoomMemberCount(roomId: string): Promise<number> {
@@ -484,6 +489,15 @@ export async function memUpdateRoomMaxWorkers(roomId: string, maxWorkers: number
   if (r) {
     r.max_workers = maxWorkers;
   } else {
-    rooms.set(roomId, { max_workers: maxWorkers, created_at: new Date() });
+    rooms.set(roomId, { max_workers: maxWorkers, allow_new_employees: false, created_at: new Date() });
+  }
+}
+
+export async function memUpdateRoomAllowNewEmployees(roomId: string, allowNewEmployees: boolean): Promise<void> {
+  const r = rooms.get(roomId);
+  if (r) {
+    r.allow_new_employees = allowNewEmployees;
+  } else {
+    rooms.set(roomId, { max_workers: 20, allow_new_employees: allowNewEmployees, created_at: new Date() });
   }
 }

--- a/src/components/ui/RoomAdminPanel.tsx
+++ b/src/components/ui/RoomAdminPanel.tsx
@@ -32,6 +32,7 @@ export const RoomAdminPanel = ({ roomId, onClose }: RoomAdminPanelProps) => {
   const [visitors, setVisitors] = useState<Visitor[]>([]);
   const [addEmail, setAddEmail] = useState('');
   const [maxWorkers, setMaxWorkers] = useState(roomInfo?.maxWorkers ?? 20);
+  const [allowNewEmployees, setAllowNewEmployees] = useState(roomInfo?.allowNewEmployees ?? false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -55,7 +56,8 @@ export const RoomAdminPanel = ({ roomId, onClose }: RoomAdminPanelProps) => {
   // Sync maxWorkers from store when it updates
   useEffect(() => {
     if (roomInfo?.maxWorkers !== undefined) setMaxWorkers(roomInfo.maxWorkers);
-  }, [roomInfo?.maxWorkers]);
+    if (roomInfo?.allowNewEmployees !== undefined) setAllowNewEmployees(roomInfo.allowNewEmployees);
+  }, [roomInfo?.maxWorkers, roomInfo?.allowNewEmployees]);
 
   const addMember = async (email: string, role: RoomRole = 'worker') => {
     console.log(`[admin] adding member email=${email} role=${role} to room=${roomId}`);
@@ -102,8 +104,8 @@ export const RoomAdminPanel = ({ roomId, onClose }: RoomAdminPanelProps) => {
     }
   };
 
-  const saveMaxWorkers = async () => {
-    console.log(`[admin] saving maxWorkers=${maxWorkers} for room=${roomId}`);
+  const saveRoomSettings = async (patch: { maxWorkers?: number; allowNewEmployees?: boolean }) => {
+    console.log(`[admin] saving room settings for room=${roomId}`, patch);
     setError(null);
     setLoading(true);
     try {
@@ -111,13 +113,13 @@ export const RoomAdminPanel = ({ roomId, onClose }: RoomAdminPanelProps) => {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ maxWorkers }),
+        body: JSON.stringify(patch),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? 'Failed to update');
-      console.log(`[admin] maxWorkers updated to ${maxWorkers}`);
+      console.log(`[admin] room settings updated`);
     } catch (e: any) {
-      console.error(`[admin] saveMaxWorkers failed:`, e.message);
+      console.error(`[admin] saveRoomSettings failed:`, e.message);
       setError(e.message);
     } finally {
       setLoading(false);
@@ -271,11 +273,38 @@ export const RoomAdminPanel = ({ roomId, onClose }: RoomAdminPanelProps) => {
                 className="w-20 bg-white border-4 border-black px-2 py-1.5 text-[9px] focus:outline-none focus:bg-yellow-50"
               />
               <button
-                onClick={saveMaxWorkers}
+                onClick={() => saveRoomSettings({ maxWorkers })}
                 disabled={loading}
                 className="pixel-button text-[9px] px-3 py-1.5 disabled:opacity-50"
               >
                 Save
+              </button>
+            </div>
+          </div>
+        )}
+
+        {myRole === 'admin' && (
+          <div>
+            <h3 className="text-[9px] uppercase text-slate-500 tracking-widest mb-2">New Employee Mode</h3>
+            <div className="bg-white pixel-border px-3 py-2 text-[9px] flex items-center justify-between gap-3">
+              <div className="flex-1">
+                <div className="font-bold">Auto-hire new joiners</div>
+                <div className="text-slate-500 mt-0.5">
+                  ON: newcomers become workers automatically and get a desk.
+                </div>
+              </div>
+              <button
+                onClick={() => {
+                  const next = !allowNewEmployees;
+                  setAllowNewEmployees(next);
+                  void saveRoomSettings({ allowNewEmployees: next });
+                }}
+                disabled={loading}
+                className={`pixel-button text-[9px] px-3 py-1.5 disabled:opacity-50 ${
+                  allowNewEmployees ? 'bg-emerald-300' : ''
+                }`}
+              >
+                {allowNewEmployees ? 'ON' : 'OFF'}
               </button>
             </div>
           </div>

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -260,8 +260,13 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
       useGameStore.getState().setRoomInfo(info);
     });
 
-    newSocket.on('roomMembersUpdated', (payload: { roomId: string; members?: RoomMember[]; maxWorkers?: number }) => {
-      console.log('[socket] roomMembersUpdated', payload.members ? `members=${payload.members.length}` : '', payload.maxWorkers !== undefined ? `maxWorkers=${payload.maxWorkers}` : '');
+    newSocket.on('roomMembersUpdated', (payload: { roomId: string; members?: RoomMember[]; maxWorkers?: number; allowNewEmployees?: boolean }) => {
+      console.log(
+        '[socket] roomMembersUpdated',
+        payload.members ? `members=${payload.members.length}` : '',
+        payload.maxWorkers !== undefined ? `maxWorkers=${payload.maxWorkers}` : '',
+        payload.allowNewEmployees !== undefined ? `allowNewEmployees=${payload.allowNewEmployees}` : ''
+      );
       const current = useGameStore.getState().roomInfo;
       if (!current) return;
       useGameStore.getState().setRoomInfo({
@@ -271,6 +276,7 @@ export function useSocket(user: AuthUser | null, currentRoom: string | null) {
           members: payload.members,
         }),
         ...(payload.maxWorkers !== undefined && { maxWorkers: payload.maxWorkers }),
+        ...(payload.allowNewEmployees !== undefined && { allowNewEmployees: payload.allowNewEmployees }),
       });
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,6 +108,7 @@ export interface RoomMember {
 export interface RoomInfo {
   roomId: string;
   maxWorkers: number;
+  allowNewEmployees: boolean;
   myRole: RoomRole | null;
   memberCount: number;
   members: RoomMember[];


### PR DESCRIPTION
### Motivation
- Provide admins an option so newcomers can be auto-hired and immediately receive a desk without manually adding them to the room member list.

### Description
- Added a migration-safe `allow_new_employees` room column (default `false`) and corresponding memory-DB field to persist the new-employee mode and keep `LOCAL_TEST` behavior consistent via `memGetRoomAllowNewEmployees`/`memUpdateRoomAllowNewEmployees` and DB `ALTER TABLE`/select/update helpers. 
- Extended room settings API `PATCH /api/room/:roomId` to accept `allowNewEmployees` alongside `maxWorkers` and to broadcast changes in `roomMembersUpdated` payloads. 
- Updated Socket.IO join flow so when `allow_new_employees` is enabled, a joining non-member is auto-inserted as a `worker` (subject to `maxWorkers`) and gets a desk via the existing `ensurePlayerDesk` flow, and `roomInfoLoaded` now includes `allowNewEmployees`. 
- Front-end updates: added `allowNewEmployees` to `RoomInfo` types, handled it in `src/hooks/useSocket.ts` updates to `roomMembersUpdated`, and added an admin-only toggle UI in `src/components/ui/RoomAdminPanel.tsx` with a `saveRoomSettings` helper to flip the mode. 

### Testing
- Ran `npm run lint` (TypeScript check) and it completed successfully. 
- Ran `npm run build` (Vite production build) and the build finished successfully (chunk size warning expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69deecdb7e988328b08f8e85d6c7200e)