### PR TITLE
Make office room IDs case-insensitive

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -217,6 +217,12 @@ function normalizeFocusDeskOwnerEmail(raw: unknown): string | null {
   return t;
 }
 
+function normalizeRoomId(raw: unknown): string {
+  if (typeof raw !== "string") return "default";
+  const value = raw.trim().toLowerCase();
+  return value.length > 0 ? value : "default";
+}
+
 async function loadAndSettleFocusEnergy(email: string): Promise<number> {
   if (isLocalTest()) return mem.memLoadAndSettleFocusEnergy(email);
   await ensureUserRow(email);
@@ -1175,11 +1181,12 @@ export async function createApp(injectedPool?: pg.Pool) {
     if (typeof roomId !== 'string' || !Array.isArray(layout)) {
       return res.status(400).json({ error: "Invalid layout" });
     }
-    await runSerializedRoomLayout(roomId, async () => {
-      await saveRoomLayout(roomId, layout as FurnitureItem[]);
+    const normalizedRoomId = normalizeRoomId(roomId);
+    await runSerializedRoomLayout(normalizedRoomId, async () => {
+      await saveRoomLayout(normalizedRoomId, layout as FurnitureItem[]);
     });
-    io.to(roomId).emit("roomLayoutUpdated", layout);
-    void broadcastDeskChairLevels(io, roomId, layout as FurnitureItem[]);
+    io.to(normalizedRoomId).emit("roomLayoutUpdated", layout);
+    void broadcastDeskChairLevels(io, normalizedRoomId, layout as FurnitureItem[]);
     res.json({ ok: true });
   });
 
@@ -1202,7 +1209,8 @@ export async function createApp(injectedPool?: pg.Pool) {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
     try {
-      const leaderboard = await getRoomLeaderboard(req.params.roomId);
+      const roomId = normalizeRoomId(req.params.roomId);
+      const leaderboard = await getRoomLeaderboard(roomId);
       res.json(leaderboard);
     } catch {
       res.status(500).json({ error: "Internal server error" });
@@ -1212,7 +1220,7 @@ export async function createApp(injectedPool?: pg.Pool) {
   app.get("/api/room/:roomId/members", async (req, res) => {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
-    const { roomId } = req.params;
+    const roomId = normalizeRoomId(req.params.roomId);
     try {
       const members = await getRoomMembers(roomId);
       const onlineEmails = new Set(
@@ -1233,7 +1241,7 @@ export async function createApp(injectedPool?: pg.Pool) {
   app.post("/api/room/:roomId/members", express.json(), async (req, res) => {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
-    const { roomId } = req.params;
+    const roomId = normalizeRoomId(req.params.roomId);
     const { email, role = 'worker' } = req.body ?? {};
     if (!email || typeof email !== 'string' || !['worker', 'manager'].includes(role)) {
       return res.status(400).json({ error: "Invalid request" });
@@ -1280,7 +1288,8 @@ export async function createApp(injectedPool?: pg.Pool) {
   app.delete("/api/room/:roomId/members/:memberEmail", async (req, res) => {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
-    const { roomId, memberEmail } = req.params;
+    const roomId = normalizeRoomId(req.params.roomId);
+    const { memberEmail } = req.params;
     try {
       const requesterRole = await getMemberRole(roomId, user.email);
       if (!requesterRole || requesterRole === 'worker') {
@@ -1333,7 +1342,7 @@ export async function createApp(injectedPool?: pg.Pool) {
   app.patch("/api/room/:roomId", express.json(), async (req, res) => {
     const user = (req as any).user;
     if (!user?.email) return res.status(401).json({ error: "Unauthorized" });
-    const { roomId } = req.params;
+    const roomId = normalizeRoomId(req.params.roomId);
     const { maxWorkers, allowNewEmployees } = req.body ?? {};
     try {
       const requesterRole = await getMemberRole(roomId, user.email);
@@ -1475,7 +1484,7 @@ io.on("connection", (socket) => {
         typeof data.focusEnergy === 'number' && Number.isFinite(data.focusEnergy)
           ? clampFocusEnergy(data.focusEnergy)
           : null;
-      const room = roomId || "default";
+      const room = normalizeRoomId(roomId);
       socket.join(room);
 
       if (!rooms[room]) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,8 @@ const KEYBOARD_MAP = [
 
 function getRoomFromURL(): string | null {
   if (typeof window === 'undefined') return null;
-  return new URLSearchParams(window.location.search).get('room');
+  const room = new URLSearchParams(window.location.search).get('room');
+  return room ? room.trim().toLowerCase() : null;
 }
 
 export default function App() {
@@ -133,9 +134,11 @@ export default function App() {
   const keyboardMap = useMemo(() => KEYBOARD_MAP, []);
 
   const handleJoin = (room: string) => {
-    console.log(`[app] joining room=${room}`);
-    localStorage.setItem('last_room', room);
-    window.location.search = `?room=${room}`;
+    const normalizedRoom = room.trim().toLowerCase();
+    if (!normalizedRoom) return;
+    console.log(`[app] joining room=${normalizedRoom}`);
+    localStorage.setItem('last_room', normalizedRoom);
+    window.location.search = `?room=${normalizedRoom}`;
   };
 
   const handleExitRoom = () => {


### PR DESCRIPTION
### Motivation
- Treat office/branch codes like `SCRANTON` and `scranton` as the same room to avoid duplicate rooms and surprising behavior. 
- Normalize room identifiers in both client and server code so joins, API calls, and broadcasts consistently reference a single canonical room id.

### Description
- Client: `getRoomFromURL` now trims and lowercases the `room` URL parameter and `handleJoin` normalizes the typed room string with `trim().toLowerCase()` before storing `last_room` or updating the URL (file: `src/App.tsx`).
- Server: added a `normalizeRoomId` helper that trims and lowercases room ids and falls back to `"default"` for empty values (file: `server.ts`).
- Applied server-side normalization to Socket.IO `joinRoom` handling so connected sockets always join the normalized room id, and to REST endpoints that accept `roomId` (including `/api/room/:roomId/*`, `/api/room-layout`, members endpoints, and leaderboard) so lookups, layout saves, broadcasts, and member operations use the canonical id.
- Updated room-related broadcasts and `runSerializedRoomLayout` calls to use the normalized room id so server-side state and notifications remain consistent.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfabe594548328a5a8fdd6471030c0)