### PR TITLE
Add bottom-right TUTORIAL button to replay office tutorial

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -416,6 +416,28 @@ export default function App() {
 
       {!isFocusSavingModeActive && !isTimerActive && (
         <div className="absolute bottom-6 right-6 z-10 flex gap-2 items-end font-pixel">
+          {/* Tutorial restart */}
+          <button
+            onClick={officeTutorial.restart}
+            title="Replay Office Tutorial"
+            style={{
+              background: 'var(--color-paper)',
+              color: 'var(--color-ink)',
+              boxShadow: '0 -2px 0 0 #000, 0 2px 0 0 #000, -2px 0 0 0 #000, 2px 0 0 0 #000',
+              border: 'none',
+              padding: '6px 10px',
+              fontSize: '8px',
+              cursor: 'pointer',
+              letterSpacing: '0.05em',
+              textTransform: 'uppercase',
+              display: 'flex',
+              alignItems: 'center',
+              gap: '6px',
+            }}
+          >
+            <span style={{ fontSize: '12px', lineHeight: 1 }}>🎬</span>
+            TUTORIAL
+          </button>
           {/* HUD memo toggle */}
           <button
             onClick={() => setShowHUD((v) => !v)}

--- a/src/hooks/useOfficeTutorial.ts
+++ b/src/hooks/useOfficeTutorial.ts
@@ -27,6 +27,10 @@ function markOfficeTutorialComplete(email: string) {
   localStorage.setItem(tutorialStorageKey(email), '1');
 }
 
+function clearOfficeTutorialCompletion(email: string) {
+  localStorage.removeItem(tutorialStorageKey(email));
+}
+
 function findMyDeskPosition(layout: FurnitureItem[], email: string): [number, number, number] | null {
   const id = `desk-${email}`;
   const item = layout.find((f): f is DeskItem => f.type === 'desk' && f.id === id);
@@ -93,6 +97,12 @@ export function useOfficeTutorial(email: string | undefined, inRoom: boolean) {
     if (email) markOfficeTutorialComplete(email);
     setPhase(null);
   }, [email]);
+
+  const restart = useCallback(() => {
+    if (!email || !inRoom || !myDeskPosition) return;
+    clearOfficeTutorialCompletion(email);
+    setPhase('intro');
+  }, [email, inRoom, myDeskPosition]);
 
   // desk → focus-energy: player actually starts a focus session
   useEffect(() => {
@@ -173,5 +183,5 @@ export function useOfficeTutorial(email: string | undefined, inRoom: boolean) {
     }
   })();
 
-  return { active: visible, phase: currentPhase, targetPosition, advance, skip };
+  return { active: visible, phase: currentPhase, targetPosition, advance, skip, restart };
 }


### PR DESCRIPTION
### Motivation
- Provide a way for players to intentionally replay the office tutorial if they want to go through it again after completing or skipping it.

### Description
- Add `clearOfficeTutorialCompletion` to remove the tutorial completion flag from `localStorage` and expose a `restart` callback from `useOfficeTutorial` that clears the flag and resets the phase to `intro` when in-room and the desk position is known.
- Wire the `restart` callback into the main HUD by adding a `TUTORIAL` button in the bottom-right control cluster that calls `officeTutorial.restart` and sits alongside the existing memo/chat toggles (`src/hooks/useOfficeTutorial.ts`, `src/App.tsx`).
- Preserve existing completion/skip behavior (`markOfficeTutorialComplete`) so normal first-visit flow is unchanged.

### Testing
- Ran `npm run lint` and it completed successfully.
- There is no automated UI test suite in this project; manual verification recommended in a running dev server (`LOCAL_TEST=1 npx tsx server.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbb0a11848328a91c3cbd8cd69d59)