### PR TITLE
Fix focus-mode presence after reconnect

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -354,6 +354,11 @@ interface DeskItem extends FurnitureItem {
   config: { ownerEmail: string; ownerName: string; [key: string]: unknown };
 }
 
+interface PersistedFocusState {
+  activeDeskId: string | null;
+  deskPosition: [number, number, number] | null;
+}
+
 function extractDeskOwnerEmails(layout: FurnitureItem[]): string[] {
   const seen = new Set<string>();
   for (const f of layout) {
@@ -362,6 +367,58 @@ function extractDeskOwnerEmails(layout: FurnitureItem[]): string[] {
     if (typeof email === "string" && email.length > 0) seen.add(email);
   }
   return [...seen];
+}
+
+function findDeskByOwnerEmail(
+  layout: FurnitureItem[],
+  ownerEmail: string
+): DeskItem | null {
+  const target = ownerEmail.trim().toLowerCase();
+  if (!target) return null;
+  for (const item of layout) {
+    if (item.type !== "desk") continue;
+    const desk = item as DeskItem;
+    const rawOwner = desk.config?.ownerEmail;
+    if (typeof rawOwner !== "string") continue;
+    if (rawOwner.trim().toLowerCase() === target) return desk;
+  }
+  return null;
+}
+
+async function loadPersistedFocusState(
+  email: string,
+  roomId: string
+): Promise<PersistedFocusState> {
+  let mode: FocusEnergyMode = "idle";
+  let deskOwnerEmail: string | null = null;
+
+  if (isLocalTest()) {
+    const snapshot = await mem.memGetFocusEnergySnapshot(email);
+    mode = snapshot.mode;
+    deskOwnerEmail = normalizeFocusDeskOwnerEmail(snapshot.deskOwnerEmail);
+  } else {
+    const { rows } = await pool!.query<{
+      focus_energy_mode: string;
+      focus_energy_desk_owner_email: string | null;
+    }>(
+      `SELECT focus_energy_mode, focus_energy_desk_owner_email
+       FROM users
+       WHERE email = $1`,
+      [email]
+    );
+    if (!rows[0]) return { activeDeskId: null, deskPosition: null };
+    mode = parseFocusEnergyMode(rows[0].focus_energy_mode);
+    deskOwnerEmail = normalizeFocusDeskOwnerEmail(rows[0].focus_energy_desk_owner_email);
+  }
+
+  if (mode !== "focus" || !deskOwnerEmail) {
+    return { activeDeskId: null, deskPosition: null };
+  }
+
+  const layout = await getRoomLayout(roomId);
+  const desk = findDeskByOwnerEmail(layout, deskOwnerEmail);
+  if (!desk) return { activeDeskId: null, deskPosition: null };
+  return { activeDeskId: desk.id, deskPosition: [...desk.position] };
 }
 
 async function getChairAndMonitorLevelsForEmails(
@@ -1571,6 +1628,19 @@ io.on("connection", (socket) => {
         wornPropId: null,
         heldThrowableId: null,
       };
+      try {
+        const persistedFocus = await loadPersistedFocusState(user.email, room);
+        if (persistedFocus.activeDeskId) {
+          rooms[room][socket.id].isFocused = true;
+          rooms[room][socket.id].activeDeskId = persistedFocus.activeDeskId;
+          rooms[room][socket.id].focusProgress = 0;
+          if (persistedFocus.deskPosition) {
+            rooms[room][socket.id].position = persistedFocus.deskPosition;
+          }
+        }
+      } catch (err) {
+        console.error("Failed to restore persisted focus state:", err);
+      }
       socketToRoom.set(socket.id, room);
 
       // Remove stale entries for the same email before sending currentPlayers.

--- a/server/memoryDb.ts
+++ b/server/memoryDb.ts
@@ -48,6 +48,11 @@ interface UserRow {
   desk_items: DeskItemPlacement[];
 }
 
+export interface FocusEnergySnapshot {
+  mode: FocusEnergyMode;
+  deskOwnerEmail: string | null;
+}
+
 interface RoomRow {
   max_workers: number;
   allow_new_employees: boolean;
@@ -305,6 +310,18 @@ export async function memSaveFocusEnergy(
       ? focusDeskOwnerEmail
       : null;
   users.set(email, u);
+}
+
+export async function memGetFocusEnergySnapshot(
+  email: string
+): Promise<FocusEnergySnapshot> {
+  const u = users.get(email) ?? defaultUserRow();
+  patchFocusEnergyFields(u);
+  users.set(email, u);
+  return {
+    mode: parseFocusEnergyMode(u.focus_energy_mode),
+    deskOwnerEmail: u.focus_energy_desk_owner_email,
+  };
 }
 
 /** On socket disconnect: settle to now with last mode, then force idle for offline regen. */


### PR DESCRIPTION
### Motivation
- Players in an active desk `focus` session were shown correctly on their own client after a reconnect but other players saw them at a random spawn position and not marked as focused, so a reconnect could produce inconsistent presence state for others.

### Description
- Read persisted focus snapshot (`focus_energy_mode` + `focus_energy_desk_owner_email`) on `joinRoom` and map it back to the room `desk` so a reconnecting player can be rehydrated as seated and focused before `currentPlayers` is emitted.
- Add `findDeskByOwnerEmail` and `loadPersistedFocusState` helpers to map `deskOwnerEmail` → `activeDeskId` and to return a seat-adjacent `deskPosition` for consistent visuals.
- Restore `isFocused`, `activeDeskId`, `focusProgress`, and player `position` in `rooms[room][socket.id]` when a persisted focus state is present, and log errors if restoration fails.
- Add `FocusEnergySnapshot` type and `memGetFocusEnergySnapshot` to `server/memoryDb.ts` to ensure `LOCAL_TEST` (in-memory DB) behaves like PostgreSQL for reconnect restoration.

### Testing
- Ran `npm run lint` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68b57331883289a1da7a76f82cdc3)