### PR TITLE
Fix stale identity-theft warning on desk focus updates

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -2164,18 +2164,28 @@ io.on("connection", (socket) => {
           nextFocused && !!nextDeskId && (!wasFocused || prevDeskId !== nextDeskId);
 
         if (startedOrSwitchedDesk) {
+          const triggerDeskId = nextDeskId;
           void getRoomLayout(playerRoom)
             .then((layout) => {
-              const deskOwnerEmail = deskOwnerEmailByDeskId(layout, nextDeskId);
-              const sittingPlayerEmail = typeof player.email === "string" ? player.email : user.email;
+              const latestPlayer = rooms[playerRoom]?.[socket.id];
+              if (!latestPlayer || !latestPlayer.isFocused) return;
+              const latestDeskId =
+                typeof latestPlayer.activeDeskId === "string" ? latestPlayer.activeDeskId : null;
+              if (!latestDeskId || latestDeskId !== triggerDeskId) return;
+
+              const deskOwnerEmail = deskOwnerEmailByDeskId(layout, triggerDeskId);
+              const sittingPlayerEmail =
+                typeof latestPlayer.email === "string" ? latestPlayer.email : user.email;
+              const normalizedDeskOwner = deskOwnerEmail?.trim().toLowerCase();
+              const normalizedSitter = sittingPlayerEmail.trim().toLowerCase();
               if (
-                deskOwnerEmail &&
-                deskOwnerEmail.toLowerCase() !== sittingPlayerEmail.toLowerCase()
+                normalizedDeskOwner &&
+                normalizedDeskOwner !== normalizedSitter
               ) {
                 const messageTime = Date.now();
-                player.lastMessage = IDENTITY_THEFT_OVERHEAD_TEXT;
-                player.lastMessageTime = messageTime;
-                player.lastMessageDurationMs = IDENTITY_THEFT_OVERHEAD_DURATION_MS;
+                latestPlayer.lastMessage = IDENTITY_THEFT_OVERHEAD_TEXT;
+                latestPlayer.lastMessageTime = messageTime;
+                latestPlayer.lastMessageDurationMs = IDENTITY_THEFT_OVERHEAD_DURATION_MS;
                 io.to(playerRoom).emit(
                   "chatMessage",
                   systemChatMessage(IDENTITY_THEFT_SYSTEM_CHAT_TEXT)


### PR DESCRIPTION
### Motivation
- Prevent spurious "identity theft" warnings that appeared when the async room layout lookup returned after a player had already changed focus or switched desks. 
- Ensure the system only emits the overhead message and system chat when the player’s current server-side state still indicates they are focusing at the same desk.

### Description
- In the `playerFocusUpdate` handler, capture `triggerDeskId` and after `getRoomLayout` resolves re-check the live player snapshot `rooms[playerRoom][socket.id]` for `isFocused` and `activeDeskId` matching the `triggerDeskId` before proceeding. 
- Normalize and compare emails using `trim().toLowerCase()` to avoid false positives due to case or surrounding whitespace. 
- Write overhead message fields to the latest player object (`lastMessage`, `lastMessageTime`, `lastMessageDurationMs`) and then emit the `chatMessage` and `ambientSpeech` events only when the checks pass.

### Testing
- Ran `npm run lint` (TypeScript `tsc --noEmit`) and it succeeded. 
- Ran `npx vitest run src/__tests__/integration/server.test.ts -t "broadcasts a system warning when a player focuses at another player desk"` and the targeted integration test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f295d008832882f15b30fc222b50)