### PR TITLE
Preserve player seat/position across brief disconnects

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1205,6 +1205,19 @@ export async function createApp(injectedPool?: pg.Pool) {
 
   // Track active users by email to prevent multiple sessions
   const activeUsers = new Map<string, string>(); // email -> socketId
+  type DisconnectedPlayerSnapshot = {
+    roomId: string;
+    position: [number, number, number];
+    rotation: [number, number, number];
+    isFocused: boolean;
+    activeDeskId: string | null;
+    focusProgress: number;
+    focusSitPoseIndex?: number;
+    disconnectedAt: number;
+  };
+  const disconnectedPlayers = new Map<string, DisconnectedPlayerSnapshot>();
+  const pendingDisconnectSettleTimers = new Map<string, NodeJS.Timeout>();
+  const DISCONNECT_RESTORE_WINDOW_MS = 2 * 60 * 1000;
 
   // Buffered movement state: flushed to clients at MOVEMENT_TICK_MS intervals
   const MOVEMENT_TICK_MS = 50; // 20 Hz
@@ -1623,6 +1636,12 @@ io.on("connection", (socket) => {
 
     console.log("User connected:", socket.id, user.email);
 
+    const pendingSettle = pendingDisconnectSettleTimers.get(user.email);
+    if (pendingSettle) {
+      clearTimeout(pendingSettle);
+      pendingDisconnectSettleTimers.delete(user.email);
+    }
+
     // Single session enforcement
     const existingSocketId = activeUsers.get(user.email);
     if (existingSocketId) {
@@ -1683,19 +1702,44 @@ io.on("connection", (socket) => {
       const spawnRotation: [number, number, number] = isValidCoord(data.rotation)
         ? data.rotation
         : [0, 0, 0];
+      const disconnectedSnapshot = disconnectedPlayers.get(user.email);
+      const canRestoreFromDisconnectSnapshot =
+        !!disconnectedSnapshot &&
+        disconnectedSnapshot.roomId === room &&
+        Date.now() - disconnectedSnapshot.disconnectedAt <= DISCONNECT_RESTORE_WINDOW_MS;
       rooms[room][socket.id] = {
         id: socket.id,
         email: user.email,
-        position: spawnPosition,
-        rotation: spawnRotation,
+        position:
+          canRestoreFromDisconnectSnapshot && disconnectedSnapshot
+            ? disconnectedSnapshot.position
+            : spawnPosition,
+        rotation:
+          canRestoreFromDisconnectSnapshot && disconnectedSnapshot
+            ? disconnectedSnapshot.rotation
+            : spawnRotation,
         color: getDeterministicColor(name),
         name: name,
         room: room,
         wornPropId: null,
         heldThrowableId: null,
       };
+      if (canRestoreFromDisconnectSnapshot && disconnectedSnapshot) {
+        rooms[room][socket.id].isFocused = disconnectedSnapshot.isFocused;
+        rooms[room][socket.id].activeDeskId = disconnectedSnapshot.activeDeskId;
+        rooms[room][socket.id].focusProgress = disconnectedSnapshot.focusProgress;
+        if (typeof disconnectedSnapshot.focusSitPoseIndex === "number") {
+          rooms[room][socket.id].focusSitPoseIndex = disconnectedSnapshot.focusSitPoseIndex;
+        }
+      }
       try {
-        const persistedFocus = await loadPersistedFocusState(user.email, room);
+        const shouldRestorePersistedFocus =
+          !canRestoreFromDisconnectSnapshot ||
+          !disconnectedSnapshot?.isFocused ||
+          !disconnectedSnapshot.activeDeskId;
+        const persistedFocus = shouldRestorePersistedFocus
+          ? await loadPersistedFocusState(user.email, room)
+          : { activeDeskId: null, deskPosition: null };
         if (persistedFocus.activeDeskId) {
           rooms[room][socket.id].isFocused = true;
           rooms[room][socket.id].activeDeskId = persistedFocus.activeDeskId;
@@ -1707,6 +1751,7 @@ io.on("connection", (socket) => {
       } catch (err) {
         console.error("Failed to restore persisted focus state:", err);
       }
+      disconnectedPlayers.delete(user.email);
       socketToRoom.set(socket.id, room);
 
       // Remove stale entries for the same email before sending currentPlayers.
@@ -2268,16 +2313,47 @@ io.on("connection", (socket) => {
     socket.on("disconnect", () => {
       console.log("User disconnected:", socket.id);
 
-      if (user?.email) {
-        void settleFocusEnergyOnDisconnect(user.email);
-      }
-
-      if (user?.email && activeUsers.get(user.email) === socket.id) {
-        activeUsers.delete(user.email);
-      }
-
       const playerRoom = socketToRoom.get(socket.id);
       if (playerRoom && rooms[playerRoom]?.[socket.id]) {
+        const disconnectedPlayer = rooms[playerRoom][socket.id];
+        if (user?.email) {
+          disconnectedPlayers.set(user.email, {
+            roomId: playerRoom,
+            position: Array.isArray(disconnectedPlayer.position)
+              ? disconnectedPlayer.position
+              : [0, 0, 0],
+            rotation: Array.isArray(disconnectedPlayer.rotation)
+              ? disconnectedPlayer.rotation
+              : [0, 0, 0],
+            isFocused: !!disconnectedPlayer.isFocused,
+            activeDeskId:
+              typeof disconnectedPlayer.activeDeskId === "string"
+                ? disconnectedPlayer.activeDeskId
+                : null,
+            focusProgress:
+              typeof disconnectedPlayer.focusProgress === "number"
+                ? disconnectedPlayer.focusProgress
+                : 0,
+            focusSitPoseIndex:
+              typeof disconnectedPlayer.focusSitPoseIndex === "number"
+                ? disconnectedPlayer.focusSitPoseIndex
+                : undefined,
+            disconnectedAt: Date.now(),
+          });
+
+          const existingTimer = pendingDisconnectSettleTimers.get(user.email);
+          if (existingTimer) clearTimeout(existingTimer);
+          const timer = setTimeout(() => {
+            const activeSocketId = activeUsers.get(user.email);
+            if (!activeSocketId) {
+              disconnectedPlayers.delete(user.email);
+              void settleFocusEnergyOnDisconnect(user.email);
+            }
+            pendingDisconnectSettleTimers.delete(user.email);
+          }, DISCONNECT_RESTORE_WINDOW_MS);
+          pendingDisconnectSettleTimers.set(user.email, timer);
+        }
+
         delete rooms[playerRoom][socket.id];
         socketToRoom.delete(socket.id);
         io.to(playerRoom).emit("playerDisconnected", socket.id);
@@ -2286,6 +2362,10 @@ io.on("connection", (socket) => {
         if (Object.keys(rooms[playerRoom]).length === 0) {
           delete rooms[playerRoom];
         }
+      }
+
+      if (user?.email && activeUsers.get(user.email) === socket.id) {
+        activeUsers.delete(user.email);
       }
     });
   });


### PR DESCRIPTION
### Motivation
- Keep players' last in-room state (position, rotation, desk/focus seat and sit pose) when they briefly lose connectivity so returning users appear in the correct place and seated state to others.
- Avoid immediately settling focus energy on transient network drops so short disconnects don't prematurely end ongoing focus sessions.
- Provide a short grace window to distinguish short network blips from a real logout/disconnect and preserve UX for reconnections.

### Description
- Introduce `DisconnectedPlayerSnapshot` and in-memory maps `disconnectedPlayers` and `pendingDisconnectSettleTimers` plus a `DISCONNECT_RESTORE_WINDOW_MS = 2 * 60 * 1000` grace window constant. 
- On `disconnect`, capture the player's room, `position`, `rotation`, `isFocused`, `activeDeskId`, `focusProgress`, and optional `focusSitPoseIndex`, store it in `disconnectedPlayers`, and start a timer that will call `settleFocusEnergyOnDisconnect` only if the player does not reconnect within the window.
- On new socket `connection`, cancel any pending settle timer for that user so a quick reconnect prevents focus settlement.
- On `joinRoom`, detect a recent disconnect snapshot for the same room and, if present and within the window, restore `position`, `rotation`, `isFocused`, `activeDeskId`, `focusProgress`, and `focusSitPoseIndex` into the in-memory player object instead of applying a random spawn; otherwise fall back to existing persisted-focus restoration logic from DB; snapshots are cleared after restore.
- Minor housekeeping: ensure `activeUsers` cleanup remains correct after disconnect processing.

### Testing
- Ran `npm run lint` (`tsc --noEmit`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6b6ca9008328818f147e4197d11c)